### PR TITLE
feat: add combat input and animation pipeline

### DIFF
--- a/server/player/handlers/socket-events/index.js
+++ b/server/player/handlers/socket-events/index.js
@@ -85,6 +85,34 @@ export default {
     Player.broadcastMovement(player);
   },
 
+  'player:skill:trigger': (data) => {
+    const payload = data.data || {};
+    const playerIndex = world.players.findIndex(player => player.uuid === payload.id);
+    if (playerIndex === -1) {
+      return;
+    }
+
+    const player = world.players[playerIndex];
+    const triggered = player.recordSkillInput(payload.skillId, {
+      direction: payload.direction,
+      modifiers: payload.modifiers,
+      animationState: payload.animationState,
+      duration: payload.duration,
+      holdState: payload.holdState,
+    });
+
+    if (!triggered) {
+      return;
+    }
+
+    Player.broadcastAnimation(player);
+    Socket.broadcast('player:combat:update', {
+      playerId: player.uuid,
+      combat: player.combat,
+      animation: player.animation,
+    });
+  },
+
   /**
    * Queue up an player action to executed they reach their destination
    */

--- a/server/player/pipeline/players.js
+++ b/server/player/pipeline/players.js
@@ -27,7 +27,12 @@ export default {
     const getRealPlacement = world.players[playerIndex].inventory.slots.findIndex(i => item.uuid === i.uuid);
     world.players[playerIndex].inventory.slots.splice(getRealPlacement, 1);
 
-    world.players[playerIndex].combat = Wear.updateCombat(playerIndex);
+    const combatStats = Wear.updateCombat(playerIndex);
+    world.players[playerIndex].combat = {
+      ...world.players[playerIndex].combat,
+      attack: combatStats.attack,
+      defense: combatStats.defense,
+    };
     Socket.broadcast('player:equippedAnItem', world.players[playerIndex]);
   },
 
@@ -63,7 +68,12 @@ export default {
 
       world.players[playerIndex].wear[getItem.slot] = null;
 
-      world.players[playerIndex].combat = Wear.updateCombat(playerIndex, true);
+      const combatStats = Wear.updateCombat(playerIndex, true);
+      world.players[playerIndex].combat = {
+        ...world.players[playerIndex].combat,
+        attack: combatStats.attack,
+        defense: combatStats.defense,
+      };
 
       Socket.broadcast('player:unequippedAnItem', world.players[playerIndex]);
       resolve(200);

--- a/server/shared/combat.js
+++ b/server/shared/combat.js
@@ -1,0 +1,42 @@
+export const DEFAULT_FACING_DIRECTION = 'down';
+
+export const PLAYER_ANIMATION_STATES = ['idle', 'run', 'attack', 'dash', 'hurt'];
+
+export const DEFAULT_ANIMATION_DURATIONS = {
+  idle: 0,
+  run: 0,
+  attack: 450,
+  dash: 300,
+  hurt: 500,
+};
+
+export const DEFAULT_ANIMATION_HOLDS = {
+  attack: 'idle',
+  dash: 'run',
+  hurt: 'idle',
+};
+
+export const GLOBAL_COOLDOWN_MS = 350;
+export const INPUT_BUFFER_MS = 250;
+export const COMBO_WINDOW_MS = 900;
+
+export const DEFAULT_SKILL_IDS = {
+  primary: 'primary-attack',
+  secondary: 'secondary-attack',
+  dash: 'dash',
+  ability1: 'ability-1',
+  ability2: 'ability-2',
+  ability3: 'ability-3',
+  ability4: 'ability-4',
+};
+
+export default {
+  DEFAULT_FACING_DIRECTION,
+  PLAYER_ANIMATION_STATES,
+  DEFAULT_ANIMATION_DURATIONS,
+  DEFAULT_ANIMATION_HOLDS,
+  GLOBAL_COOLDOWN_MS,
+  INPUT_BUFFER_MS,
+  COMBO_WINDOW_MS,
+  DEFAULT_SKILL_IDS,
+};

--- a/src/core/config/animation.js
+++ b/src/core/config/animation.js
@@ -1,0 +1,62 @@
+import {
+  DEFAULT_FACING_DIRECTION,
+  DEFAULT_ANIMATION_DURATIONS,
+  DEFAULT_ANIMATION_HOLDS,
+} from 'shared/combat';
+
+const baseRows = {
+  down: 0,
+  left: 1,
+  right: 2,
+  up: 3,
+};
+
+const baseFrames = [0, 1, 2, 1];
+
+export const PLAYER_SPRITE_CONFIG = {
+  tileSize: 32,
+  defaultState: 'idle',
+  defaultDirection: DEFAULT_FACING_DIRECTION,
+  states: {
+    idle: {
+      frames: [1],
+      frameDuration: 480,
+      rows: baseRows,
+      loop: true,
+      holdState: null,
+    },
+    run: {
+      frames: baseFrames,
+      frameDuration: 110,
+      rows: baseRows,
+      loop: true,
+      holdState: null,
+    },
+    attack: {
+      frames: [2, 1, 0, 1],
+      frameDuration: 90,
+      rows: baseRows,
+      loop: false,
+      holdState: DEFAULT_ANIMATION_HOLDS.attack,
+      duration: DEFAULT_ANIMATION_DURATIONS.attack,
+    },
+    dash: {
+      frames: [0, 2, 1, 2],
+      frameDuration: 70,
+      rows: baseRows,
+      loop: false,
+      holdState: DEFAULT_ANIMATION_HOLDS.dash,
+      duration: DEFAULT_ANIMATION_DURATIONS.dash,
+    },
+    hurt: {
+      frames: [2, 2, 1, 1],
+      frameDuration: 120,
+      rows: baseRows,
+      loop: false,
+      holdState: DEFAULT_ANIMATION_HOLDS.hurt,
+      duration: DEFAULT_ANIMATION_DURATIONS.hurt,
+    },
+  },
+};
+
+export default PLAYER_SPRITE_CONFIG;

--- a/src/core/config/controls.js
+++ b/src/core/config/controls.js
@@ -1,0 +1,58 @@
+export const MOVEMENT_BINDINGS = {
+  up: ['w', 'arrowup'],
+  down: ['s', 'arrowdown'],
+  left: ['a', 'arrowleft'],
+  right: ['d', 'arrowright'],
+};
+
+export const DIAGONAL_BINDINGS = [
+  ['up', 'right', 'up-right'],
+  ['down', 'right', 'down-right'],
+  ['up', 'left', 'up-left'],
+  ['down', 'left', 'down-left'],
+];
+
+export const SKILL_BINDINGS = [
+  {
+    id: 'primary-attack',
+    keys: [' '],
+    type: 'press',
+  },
+  {
+    id: 'dash',
+    keys: ['shift'],
+    type: 'press',
+  },
+  {
+    id: 'ability-1',
+    keys: ['q'],
+    type: 'press',
+  },
+  {
+    id: 'ability-2',
+    keys: ['e'],
+    type: 'press',
+  },
+  {
+    id: 'ability-3',
+    keys: ['r'],
+    type: 'press',
+  },
+  {
+    id: 'ability-4',
+    keys: ['f'],
+    type: 'press',
+  },
+];
+
+export const MOVEMENT_REPEAT = {
+  initialDelayMs: 150,
+  repeatDelayMs: 110,
+};
+
+export default {
+  MOVEMENT_BINDINGS,
+  DIAGONAL_BINDINGS,
+  SKILL_BINDINGS,
+  MOVEMENT_REPEAT,
+};

--- a/src/core/utilities/input-controller.js
+++ b/src/core/utilities/input-controller.js
@@ -1,0 +1,236 @@
+import {
+  MOVEMENT_BINDINGS,
+  DIAGONAL_BINDINGS,
+  SKILL_BINDINGS,
+  MOVEMENT_REPEAT,
+} from '../config/controls';
+
+const NORMALISED_SPECIAL_KEYS = {
+  space: ' ',
+  spacebar: ' ',
+};
+
+const MOVEMENT_KEYS = new Set(
+  Object.values(MOVEMENT_BINDINGS)
+    .reduce((acc, keys) => acc.concat(keys), [])
+    .map((key) => key.toLowerCase()),
+);
+
+const SKILL_KEY_LOOKUP = SKILL_BINDINGS.reduce((acc, binding) => {
+  binding.keys.forEach((key) => {
+    acc.set(key.toLowerCase(), binding);
+  });
+  return acc;
+}, new Map());
+
+class InputController {
+  constructor(options = {}) {
+    this.onMove = options.onMove || null;
+    this.onStop = options.onStop || null;
+    this.onSkill = options.onSkill || null;
+
+    this.pressedKeys = new Set();
+    this.activeDirection = null;
+    this.repeatTimeout = null;
+    this.repeatInterval = null;
+  }
+
+  destroy() {
+    this.clearRepeat();
+    this.pressedKeys.clear();
+  }
+
+  normaliseKey(rawKey) {
+    if (!rawKey) {
+      return '';
+    }
+    const lower = rawKey.toLowerCase();
+    if (NORMALISED_SPECIAL_KEYS[lower] !== undefined) {
+      return NORMALISED_SPECIAL_KEYS[lower];
+    }
+    return lower;
+  }
+
+  handleKeyDown(event) {
+    const key = this.normaliseKey(event.key);
+    if (!key) {
+      return false;
+    }
+
+    if (this.isMovementKey(key)) {
+      if (!this.pressedKeys.has(key)) {
+        this.pressedKeys.add(key);
+        this.updateMovement(true);
+      }
+      return true;
+    }
+
+    const binding = this.getSkillBinding(key);
+    if (binding) {
+      if (event && event.repeat) {
+        return true;
+      }
+      this.triggerSkill(binding, 'start', event);
+      return true;
+    }
+
+    return false;
+  }
+
+  handleKeyUp(event) {
+    const key = this.normaliseKey(event.key);
+    if (!key) {
+      return false;
+    }
+
+    let handled = false;
+    if (this.pressedKeys.has(key)) {
+      this.pressedKeys.delete(key);
+      this.updateMovement(false);
+      handled = true;
+    }
+
+    const binding = this.getSkillBinding(key);
+    if (binding && binding.type === 'hold') {
+      this.triggerSkill(binding, 'end', event);
+      handled = true;
+    }
+
+    if (binding && binding.type !== 'hold') {
+      handled = true;
+    }
+
+    return handled;
+  }
+
+  isMovementKey(key) {
+    return MOVEMENT_KEYS.has(key);
+  }
+
+  getSkillBinding(key) {
+    return SKILL_KEY_LOOKUP.get(key) || null;
+  }
+
+  updateMovement(initialTrigger = false) {
+    const direction = this.computeDirection();
+
+    if (!direction) {
+      if (this.activeDirection && typeof this.onStop === 'function') {
+        this.onStop(this.activeDirection);
+      }
+      this.activeDirection = null;
+      this.clearRepeat();
+      return;
+    }
+
+    if (direction !== this.activeDirection || initialTrigger) {
+      this.activeDirection = direction;
+      if (typeof this.onMove === 'function') {
+        this.onMove(direction, { initial: true });
+      }
+      this.restartRepeat();
+      return;
+    }
+
+    this.ensureRepeat();
+  }
+
+  computeDirection() {
+    const has = (keys) => keys.some((key) => this.pressedKeys.has(key));
+
+    const up = has(MOVEMENT_BINDINGS.up);
+    const down = has(MOVEMENT_BINDINGS.down);
+    const left = has(MOVEMENT_BINDINGS.left);
+    const right = has(MOVEMENT_BINDINGS.right);
+
+    if ((up && down) || (left && right)) {
+      return null;
+    }
+
+    for (let i = 0; i < DIAGONAL_BINDINGS.length; i += 1) {
+      const [vertical, horizontal, diagonal] = DIAGONAL_BINDINGS[i];
+      if (vertical === 'up' && horizontal === 'right' && up && right) {
+        return diagonal;
+      }
+      if (vertical === 'down' && horizontal === 'right' && down && right) {
+        return diagonal;
+      }
+      if (vertical === 'up' && horizontal === 'left' && up && left) {
+        return diagonal;
+      }
+      if (vertical === 'down' && horizontal === 'left' && down && left) {
+        return diagonal;
+      }
+    }
+
+    if (up) return 'up';
+    if (down) return 'down';
+    if (left) return 'left';
+    if (right) return 'right';
+
+    return null;
+  }
+
+  restartRepeat() {
+    this.clearRepeat();
+    if (!this.activeDirection) {
+      return;
+    }
+
+    this.repeatTimeout = setTimeout(() => {
+      if (!this.activeDirection) {
+        return;
+      }
+      if (typeof this.onMove === 'function') {
+        this.onMove(this.activeDirection, { repeated: true });
+      }
+      this.repeatInterval = setInterval(() => {
+        if (!this.activeDirection) {
+          this.clearRepeat();
+          return;
+        }
+        if (typeof this.onMove === 'function') {
+          this.onMove(this.activeDirection, { repeated: true });
+        }
+      }, MOVEMENT_REPEAT.repeatDelayMs);
+    }, MOVEMENT_REPEAT.initialDelayMs);
+  }
+
+  ensureRepeat() {
+    if (this.repeatTimeout !== null || this.repeatInterval !== null) {
+      return;
+    }
+    this.restartRepeat();
+  }
+
+  clearRepeat() {
+    if (this.repeatTimeout !== null) {
+      clearTimeout(this.repeatTimeout);
+      this.repeatTimeout = null;
+    }
+    if (this.repeatInterval !== null) {
+      clearInterval(this.repeatInterval);
+      this.repeatInterval = null;
+    }
+  }
+
+  triggerSkill(binding, phase, event) {
+    if (!binding) {
+      return;
+    }
+
+    if (binding.type !== 'hold' && phase !== 'start') {
+      return;
+    }
+
+    if (typeof this.onSkill === 'function') {
+      this.onSkill({
+        skillId: binding.id,
+        phase,
+        event,
+      });
+    }
+  }
+}
+
+export default InputController;

--- a/src/core/utilities/sprite-animator.js
+++ b/src/core/utilities/sprite-animator.js
@@ -1,0 +1,218 @@
+import { DEFAULT_FACING_DIRECTION } from 'shared/combat';
+
+const FALLBACK_FRAME_DURATION = 120;
+
+class SpriteAnimator {
+  constructor(config = {}) {
+    this.config = config || {};
+    this.state = config.defaultState || 'idle';
+    this.direction = config.defaultDirection || DEFAULT_FACING_DIRECTION;
+    this.sequence = 0;
+    this.startedAt = Date.now();
+    this.duration = 0;
+    this.speed = 1;
+    this.skillId = null;
+    this.frameIndex = 0;
+    this.elapsedMs = 0;
+    this.holdState = null;
+    this.holdApplied = false;
+    this.localState = false;
+  }
+
+  clone() {
+    const animator = new SpriteAnimator(this.config);
+    animator.applyServerState(this.toJSON());
+    return animator;
+  }
+
+  getStateConfig(state = this.state) {
+    if (!this.config || !this.config.states) {
+      return null;
+    }
+    return this.config.states[state] || null;
+  }
+
+  getFrameSequence(stateConfig = this.getStateConfig()) {
+    if (!stateConfig || !Array.isArray(stateConfig.frames) || !stateConfig.frames.length) {
+      return [0];
+    }
+    return stateConfig.frames;
+  }
+
+  getFrameDurationMs(stateConfig = this.getStateConfig()) {
+    if (!stateConfig) {
+      return FALLBACK_FRAME_DURATION;
+    }
+    const duration = Number(stateConfig.frameDuration);
+    if (Number.isFinite(duration) && duration > 0) {
+      return duration;
+    }
+    return FALLBACK_FRAME_DURATION;
+  }
+
+  resolveRow(stateConfig = this.getStateConfig(), direction = this.direction) {
+    if (stateConfig && stateConfig.rows) {
+      const value = stateConfig.rows[direction];
+      if (Number.isFinite(value)) {
+        return value;
+      }
+    }
+
+    const fallbackState = this.config && this.config.states
+      ? this.config.states[this.config.defaultState]
+      : null;
+
+    if (fallbackState && fallbackState.rows) {
+      const fallbackValue = fallbackState.rows[direction];
+      if (Number.isFinite(fallbackValue)) {
+        return fallbackValue;
+      }
+    }
+
+    return 0;
+  }
+
+  getCurrentFrame() {
+    const stateConfig = this.getStateConfig();
+    const frames = this.getFrameSequence(stateConfig);
+    const safeIndex = Math.min(Math.max(this.frameIndex, 0), frames.length - 1);
+    return {
+      state: this.state,
+      direction: this.direction,
+      column: frames[safeIndex] || 0,
+      row: this.resolveRow(stateConfig, this.direction),
+    };
+  }
+
+  update(deltaSeconds = 0) {
+    const stateConfig = this.getStateConfig();
+    if (!stateConfig) {
+      return this.getCurrentFrame();
+    }
+
+    const frames = this.getFrameSequence(stateConfig);
+    if (!frames.length) {
+      return this.getCurrentFrame();
+    }
+
+    const frameDurationMs = this.getFrameDurationMs(stateConfig) / Math.max(this.speed || 1, 0.001);
+    const deltaMs = Math.max(0, deltaSeconds * 1000);
+    this.elapsedMs += deltaMs;
+
+    let advanced = false;
+    while (this.elapsedMs >= frameDurationMs && frameDurationMs > 0) {
+      this.elapsedMs -= frameDurationMs;
+      advanced = true;
+      if (this.frameIndex + 1 < frames.length) {
+        this.frameIndex += 1;
+      } else if (stateConfig.loop !== false) {
+        this.frameIndex = 0;
+      } else {
+        this.frameIndex = frames.length - 1;
+        this.elapsedMs = 0;
+        break;
+      }
+    }
+
+    if (this.localState && this.duration > 0) {
+      const elapsed = Date.now() - this.startedAt;
+      if (elapsed >= this.duration && this.holdState && !this.holdApplied) {
+        this.setState(this.holdState, {
+          direction: this.direction,
+          local: true,
+        });
+        this.holdApplied = true;
+      }
+    }
+
+    if (!advanced && !this.localState && this.duration > 0) {
+      const elapsed = Date.now() - this.startedAt;
+      if (elapsed >= this.duration && this.holdState && !this.holdApplied) {
+        this.holdApplied = true;
+      }
+    }
+
+    return this.getCurrentFrame();
+  }
+
+  setState(state, options = {}) {
+    const stateConfig = this.getStateConfig(state) || this.getStateConfig(this.config.defaultState) || null;
+    const resolvedState = stateConfig ? state : this.state;
+    const direction = options.direction || this.direction || DEFAULT_FACING_DIRECTION;
+
+    const baseSequence = Math.floor(Number.isFinite(this.sequence) ? this.sequence : 0);
+    let sequence = options.sequence;
+    if (!Number.isFinite(sequence)) {
+      sequence = options.local ? baseSequence + 0.5 : baseSequence + 1;
+    }
+
+    this.state = resolvedState;
+    this.direction = direction;
+    this.sequence = sequence;
+    this.startedAt = Number.isFinite(options.startedAt) ? options.startedAt : Date.now();
+    this.duration = Number.isFinite(options.duration)
+      ? options.duration
+      : (stateConfig && Number.isFinite(stateConfig.duration) ? stateConfig.duration : 0);
+    this.speed = Number.isFinite(options.speed) ? options.speed : 1;
+    this.skillId = options.skillId || null;
+    this.holdState = options.holdState !== undefined
+      ? options.holdState
+      : (stateConfig ? stateConfig.holdState || null : null);
+    this.holdApplied = false;
+    this.localState = Boolean(options.local);
+    this.frameIndex = 0;
+    this.elapsedMs = 0;
+
+    return this.getCurrentFrame();
+  }
+
+  applyServerState(snapshot = {}) {
+    if (!snapshot || typeof snapshot !== 'object') {
+      return false;
+    }
+
+    const incomingSequence = Number.isFinite(snapshot.sequence) ? snapshot.sequence : null;
+    const currentFloor = Math.floor(Number.isFinite(this.sequence) ? this.sequence : 0);
+    if (incomingSequence !== null && incomingSequence < currentFloor) {
+      return false;
+    }
+
+    const state = snapshot.state || this.config.defaultState || this.state;
+    const direction = snapshot.direction || this.direction || DEFAULT_FACING_DIRECTION;
+    const stateConfig = this.getStateConfig(state) || this.getStateConfig(this.config.defaultState) || null;
+
+    this.state = stateConfig ? state : this.state;
+    this.direction = direction;
+    this.sequence = incomingSequence !== null ? incomingSequence : this.sequence;
+    this.startedAt = Number.isFinite(snapshot.startedAt) ? snapshot.startedAt : Date.now();
+    this.duration = Number.isFinite(snapshot.duration)
+      ? snapshot.duration
+      : (stateConfig && Number.isFinite(stateConfig.duration) ? stateConfig.duration : 0);
+    this.speed = Number.isFinite(snapshot.speed) ? snapshot.speed : 1;
+    this.skillId = snapshot.skillId || null;
+    this.holdState = snapshot.holdState !== undefined
+      ? snapshot.holdState
+      : (stateConfig ? stateConfig.holdState || null : null);
+    this.holdApplied = false;
+    this.localState = false;
+    this.frameIndex = 0;
+    this.elapsedMs = 0;
+
+    return true;
+  }
+
+  toJSON() {
+    return {
+      state: this.state,
+      direction: this.direction,
+      sequence: this.sequence,
+      startedAt: this.startedAt,
+      duration: this.duration,
+      speed: this.speed,
+      skillId: this.skillId,
+      holdState: this.holdState,
+    };
+  }
+}
+
+export default SpriteAnimator;


### PR DESCRIPTION
## Summary
- introduce configurable WASD combat input with predictive skill dispatching and local animation hints
- add sprite animation controllers for players/NPCs and expose animation metadata through movement/skill events
- extend server combat pipeline to track cooldowns, broadcast animation/combat updates, and share combat constants via a new module

## Testing
- npm test *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68fd430bf04483219cd2e0a53f7e4c44