### PR TITLE
feat: add Flower of Life passive tree

### DIFF
--- a/server/shared/passives/flower-of-life.js
+++ b/server/shared/passives/flower-of-life.js
@@ -1,0 +1,499 @@
+const FLOWER_OF_LIFE_LAYOUT = {
+  viewBox: 640,
+  center: 320,
+  ringSpacing: 120,
+  radii: {
+    keystone: 38,
+    notable: 30,
+    major: 30,
+    minor: 24,
+    default: 26,
+  },
+};
+
+const FLOWER_OF_LIFE_NODES = [
+  {
+    id: 'heart-of-bloom',
+    label: 'Heart of Bloom',
+    summary: 'Awaken the Flower and gain +5 to all attributes.',
+    description: 'The living core of Delaford\'s Flower of Life. Binding to it channels latent anima into your form.',
+    type: 'keystone',
+    ring: 0,
+    angle: 0,
+    cost: 1,
+    requires: [],
+    gates: [
+      { id: 'heart-of-bloom-level', type: 'level', level: 1 },
+      { id: 'heart-of-bloom-seed', type: 'quest', questId: 'seed-of-life' },
+    ],
+    rewards: ['+5 Strength', '+5 Dexterity', '+5 Intelligence'],
+  },
+  {
+    id: 'petal-of-vigor',
+    label: 'Petal of Vigor',
+    summary: '+12% maximum life.',
+    description: 'Every pulse of the flower reinforces your vitality.',
+    type: 'notable',
+    ring: 1,
+    angle: 90,
+    cost: 1,
+    requires: ['heart-of-bloom'],
+    gates: [
+      { id: 'petal-of-vigor-level', type: 'level', level: 3 },
+    ],
+    rewards: ['+12% maximum life'],
+  },
+  {
+    id: 'petal-of-precision',
+    label: 'Petal of Precision',
+    summary: '+6% critical strike chance.',
+    description: 'Focus the blossom\'s geometry into razor focus.',
+    type: 'notable',
+    ring: 1,
+    angle: 30,
+    cost: 1,
+    requires: ['heart-of-bloom'],
+    gates: [
+      { id: 'petal-of-precision-level', type: 'level', level: 3 },
+    ],
+    rewards: ['+6% critical strike chance'],
+  },
+  {
+    id: 'petal-of-celerity',
+    label: 'Petal of Celerity',
+    summary: '+8% movement speed.',
+    description: 'Let the flower\'s rhythm guide each stride.',
+    type: 'notable',
+    ring: 1,
+    angle: 330,
+    cost: 1,
+    requires: ['heart-of-bloom'],
+    gates: [
+      { id: 'petal-of-celerity-level', type: 'level', level: 3 },
+    ],
+    rewards: ['+8% movement speed'],
+  },
+  {
+    id: 'petal-of-resilience',
+    label: 'Petal of Resilience',
+    summary: '+15% to all resistances.',
+    description: 'Crystalline petals weave a ward against the elements.',
+    type: 'notable',
+    ring: 1,
+    angle: 270,
+    cost: 1,
+    requires: ['heart-of-bloom'],
+    gates: [
+      { id: 'petal-of-resilience-level', type: 'level', level: 3 },
+    ],
+    rewards: ['+15% to all resistances'],
+  },
+  {
+    id: 'petal-of-focus',
+    label: 'Petal of Focus',
+    summary: '+18% maximum mana.',
+    description: 'Drink deep from the well of conscious intention.',
+    type: 'notable',
+    ring: 1,
+    angle: 210,
+    cost: 1,
+    requires: ['heart-of-bloom'],
+    gates: [
+      { id: 'petal-of-focus-level', type: 'level', level: 3 },
+    ],
+    rewards: ['+18% maximum mana'],
+  },
+  {
+    id: 'petal-of-prowess',
+    label: 'Petal of Prowess',
+    summary: '+12% attack and spell power.',
+    description: 'Direct the lattice into raw offensive intent.',
+    type: 'notable',
+    ring: 1,
+    angle: 150,
+    cost: 1,
+    requires: ['heart-of-bloom'],
+    gates: [
+      { id: 'petal-of-prowess-level', type: 'level', level: 3 },
+    ],
+    rewards: ['+12% attack damage', '+12% spell power'],
+  },
+  {
+    id: 'bloom-channel',
+    label: 'Channel Bloom',
+    summary: '+1 additional support rune socket.',
+    description: 'Carve a resonant pathway through the lattice, empowering linked magic.',
+    type: 'major',
+    ring: 2,
+    angle: 60,
+    cost: 2,
+    requires: ['petal-of-vigor', 'petal-of-precision'],
+    gates: [
+      { id: 'bloom-channel-level', type: 'level', level: 10 },
+    ],
+    rewards: ['+1 support rune socket'],
+  },
+  {
+    id: 'bloom-reach',
+    label: 'Bloom Reach',
+    summary: '+20% area of effect.',
+    description: 'Extend the lattice outward, bathing foes in radiant force.',
+    type: 'major',
+    ring: 2,
+    angle: 0,
+    cost: 2,
+    requires: ['petal-of-precision', 'petal-of-celerity'],
+    gates: [
+      { id: 'bloom-reach-level', type: 'level', level: 10 },
+    ],
+    rewards: ['+20% area of effect'],
+  },
+  {
+    id: 'bloom-ward',
+    label: 'Bloom Ward',
+    summary: '+600 ward and refreshes 50% faster.',
+    description: 'Encircle yourself in petals that absorb the unthinkable.',
+    type: 'major',
+    ring: 2,
+    angle: 300,
+    cost: 2,
+    requires: ['petal-of-celerity', 'petal-of-resilience'],
+    gates: [
+      { id: 'bloom-ward-level', type: 'level', level: 12 },
+    ],
+    rewards: ['+600 ward', 'Ward recharge delay -50%'],
+  },
+  {
+    id: 'bloom-anchor',
+    label: 'Bloom Anchor',
+    summary: 'Cannot be stunned while above 70% life.',
+    description: 'Anchor your spirit to the flower\'s rhythm and shrug off disruption.',
+    type: 'major',
+    ring: 2,
+    angle: 240,
+    cost: 2,
+    requires: ['petal-of-resilience', 'petal-of-focus'],
+    gates: [
+      { id: 'bloom-anchor-level', type: 'level', level: 12 },
+    ],
+    rewards: ['Cannot be stunned above 70% life'],
+  },
+  {
+    id: 'bloom-surge',
+    label: 'Bloom Surge',
+    summary: '+30% spell haste after spending mana.',
+    description: 'Every expenditure of mana triggers a cascade of flow.',
+    type: 'major',
+    ring: 2,
+    angle: 180,
+    cost: 2,
+    requires: ['petal-of-focus', 'petal-of-prowess'],
+    gates: [
+      { id: 'bloom-surge-level', type: 'level', level: 14 },
+    ],
+    rewards: ['+30% spell haste for 4s after spending mana'],
+  },
+  {
+    id: 'bloom-fury',
+    label: 'Bloom Fury',
+    summary: '+25% ramping damage while stationary.',
+    description: 'Root yourself in the flower and unleash inevitable devastation.',
+    type: 'major',
+    ring: 2,
+    angle: 120,
+    cost: 2,
+    requires: ['petal-of-prowess', 'petal-of-vigor'],
+    gates: [
+      { id: 'bloom-fury-level', type: 'level', level: 14 },
+    ],
+    rewards: ['+25% damage per second while stationary (max +125%)'],
+  },
+];
+
+const FLOWER_OF_LIFE_CONNECTIONS = [
+  { id: 'heart-vigor', from: 'heart-of-bloom', to: 'petal-of-vigor' },
+  { id: 'heart-precision', from: 'heart-of-bloom', to: 'petal-of-precision' },
+  { id: 'heart-celerity', from: 'heart-of-bloom', to: 'petal-of-celerity' },
+  { id: 'heart-resilience', from: 'heart-of-bloom', to: 'petal-of-resilience' },
+  { id: 'heart-focus', from: 'heart-of-bloom', to: 'petal-of-focus' },
+  { id: 'heart-prowess', from: 'heart-of-bloom', to: 'petal-of-prowess' },
+  { id: 'vigor-precision', from: 'petal-of-vigor', to: 'petal-of-precision' },
+  { id: 'precision-celerity', from: 'petal-of-precision', to: 'petal-of-celerity' },
+  { id: 'celerity-resilience', from: 'petal-of-celerity', to: 'petal-of-resilience' },
+  { id: 'resilience-focus', from: 'petal-of-resilience', to: 'petal-of-focus' },
+  { id: 'focus-prowess', from: 'petal-of-focus', to: 'petal-of-prowess' },
+  { id: 'prowess-vigor', from: 'petal-of-prowess', to: 'petal-of-vigor' },
+  { id: 'vigor-channel', from: 'petal-of-vigor', to: 'bloom-channel' },
+  { id: 'precision-channel', from: 'petal-of-precision', to: 'bloom-channel' },
+  { id: 'precision-reach', from: 'petal-of-precision', to: 'bloom-reach' },
+  { id: 'celerity-reach', from: 'petal-of-celerity', to: 'bloom-reach' },
+  { id: 'celerity-ward', from: 'petal-of-celerity', to: 'bloom-ward' },
+  { id: 'resilience-ward', from: 'petal-of-resilience', to: 'bloom-ward' },
+  { id: 'resilience-anchor', from: 'petal-of-resilience', to: 'bloom-anchor' },
+  { id: 'focus-anchor', from: 'petal-of-focus', to: 'bloom-anchor' },
+  { id: 'focus-surge', from: 'petal-of-focus', to: 'bloom-surge' },
+  { id: 'prowess-surge', from: 'petal-of-prowess', to: 'bloom-surge' },
+  { id: 'prowess-fury', from: 'petal-of-prowess', to: 'bloom-fury' },
+  { id: 'vigor-fury', from: 'petal-of-vigor', to: 'bloom-fury' },
+];
+
+const FLOWER_OF_LIFE_PETAL_GATES = [
+  {
+    id: 'seed-of-life',
+    label: 'Awaken the Seed',
+    description: 'Complete the prologue questline that binds you to the Flower.',
+    type: 'quest',
+    questId: 'seed-of-life',
+    reward: 1,
+  },
+  {
+    id: 'level-5',
+    label: 'Reach Level 5',
+    description: 'Level requirement milestone.',
+    type: 'level',
+    level: 5,
+    reward: 1,
+  },
+  {
+    id: 'level-10',
+    label: 'Reach Level 10',
+    description: 'Level requirement milestone.',
+    type: 'level',
+    level: 10,
+    reward: 1,
+  },
+  {
+    id: 'level-15',
+    label: 'Reach Level 15',
+    description: 'Level requirement milestone.',
+    type: 'level',
+    level: 15,
+    reward: 1,
+  },
+  {
+    id: 'level-20',
+    label: 'Reach Level 20',
+    description: 'Level requirement milestone.',
+    type: 'level',
+    level: 20,
+    reward: 1,
+  },
+  {
+    id: 'ritual-of-bloom',
+    label: 'Complete a Bloom Ritual',
+    description: 'Major story or encounter reward that grants an extra petal.',
+    type: 'manual',
+    progressKey: 'rituals',
+    min: 1,
+    reward: 1,
+  },
+];
+
+const FLOWER_OF_LIFE_NODE_MAP = FLOWER_OF_LIFE_NODES.reduce((acc, node) => {
+  acc[node.id] = node;
+  return acc;
+}, {});
+
+const FLOWER_OF_LIFE_DEPENDENT_MAP = FLOWER_OF_LIFE_NODES.reduce((acc, node) => {
+  if (!Array.isArray(node.requires)) {
+    return acc;
+  }
+
+  node.requires.forEach((dependencyId) => {
+    if (!acc[dependencyId]) {
+      acc[dependencyId] = [];
+    }
+    if (!acc[dependencyId].includes(node.id)) {
+      acc[dependencyId].push(node.id);
+    }
+  });
+
+  return acc;
+}, {});
+
+const FLOWER_OF_LIFE_DEFAULT_PROGRESS = {
+  allocatedNodes: [],
+  manualMilestones: {},
+  counters: {},
+  bonusPetals: 0,
+  lastResetAt: null,
+};
+
+function normalisePlayerLevel(player = {}) {
+  const level = Number(player.level);
+  if (Number.isFinite(level) && level > 0) {
+    return level;
+  }
+
+  const statsLevel = Number(player.stats && player.stats.level);
+  if (Number.isFinite(statsLevel) && statsLevel > 0) {
+    return statsLevel;
+  }
+
+  return 1;
+}
+
+function toArray(value) {
+  if (!value) {
+    return [];
+  }
+  if (Array.isArray(value)) {
+    return value;
+  }
+  if (value instanceof Set) {
+    return Array.from(value);
+  }
+  if (typeof value === 'object') {
+    return Object.keys(value).filter(key => Boolean(value[key]));
+  }
+  return [value];
+}
+
+function hasQuestCompletion(player = {}, questId) {
+  if (!questId) {
+    return false;
+  }
+  const questKey = String(questId).toLowerCase();
+  const sources = [
+    player.quests && player.quests.completed,
+    player.questsCompleted,
+    player.completedQuests,
+    player.progression && player.progression.quests && player.progression.quests.completed,
+    player.progress && player.progress.quests && player.progress.quests.completed,
+  ];
+
+  return sources.some((source) => {
+    const list = toArray(source).map(entry => String(entry).toLowerCase());
+    return list.includes(questKey);
+  });
+}
+
+function evaluateGate(gate = {}, context = {}) {
+  const { player = {}, progress = FLOWER_OF_LIFE_DEFAULT_PROGRESS } = context;
+  const result = {
+    id: gate.id,
+    achieved: true,
+    manual: false,
+    manualComplete: false,
+    reason: null,
+    type: gate.type || 'static',
+    reward: gate.reward || 0,
+  };
+
+  if (!gate || !gate.type) {
+    return result;
+  }
+
+  switch (gate.type) {
+    case 'level': {
+      const requiredLevel = Number(gate.level) || 1;
+      const level = normalisePlayerLevel(player);
+      const achieved = level >= requiredLevel;
+      result.achieved = achieved;
+      result.requiredLevel = requiredLevel;
+      result.currentLevel = level;
+      if (!achieved) {
+        result.reason = `Reach level ${requiredLevel}`;
+      }
+      break;
+    }
+    case 'quest': {
+      const questId = gate.questId || gate.quest || gate.id;
+      const manualComplete = Boolean(progress.manualMilestones && progress.manualMilestones[gate.id]);
+      const completed = hasQuestCompletion(player, questId) || manualComplete;
+      result.achieved = completed;
+      result.manual = !hasQuestCompletion(player, questId);
+      result.manualComplete = manualComplete;
+      if (!completed) {
+        result.reason = 'Complete the quest';
+      }
+      break;
+    }
+    case 'manual': {
+      const key = gate.progressKey || gate.key || gate.id;
+      const min = Number.isFinite(gate.min) ? gate.min : 1;
+      const counterValue = (progress.counters && Number(progress.counters[key])) || 0;
+      const manualComplete = Boolean(progress.manualMilestones && progress.manualMilestones[gate.id]);
+      const achieved = manualComplete || counterValue >= min;
+      result.achieved = achieved;
+      result.manual = true;
+      result.manualComplete = manualComplete;
+      result.counterValue = counterValue;
+      result.requiredCount = min;
+      if (!achieved) {
+        result.reason = `Mark completion (${counterValue}/${min})`;
+      }
+      break;
+    }
+    default: {
+      const manualComplete = Boolean(progress.manualMilestones && progress.manualMilestones[gate.id]);
+      result.achieved = manualComplete;
+      result.manual = true;
+      result.manualComplete = manualComplete;
+      if (!manualComplete) {
+        result.reason = 'Mark completion';
+      }
+      break;
+    }
+  }
+
+  return result;
+}
+
+function computeAvailablePetalCount(player = {}, progress = FLOWER_OF_LIFE_DEFAULT_PROGRESS) {
+  const gates = FLOWER_OF_LIFE_PETAL_GATES.map((gate) => {
+    const evaluation = evaluateGate(gate, { player, progress });
+    return {
+      ...gate,
+      evaluation,
+    };
+  });
+
+  const totalFromGates = gates.reduce((sum, gate) => (
+    gate.evaluation.achieved ? sum + (gate.reward || 0) : sum
+  ), 0);
+
+  const bonus = Number(progress.bonusPetals) || 0;
+
+  return {
+    total: totalFromGates + Math.max(0, bonus),
+    gates,
+    bonusPetals: Math.max(0, bonus),
+  };
+}
+
+function sumAllocatedCost(nodeIds = []) {
+  return nodeIds.reduce((sum, nodeId) => {
+    const node = FLOWER_OF_LIFE_NODE_MAP[nodeId];
+    if (!node) {
+      return sum;
+    }
+    return sum + Math.max(0, Number(node.cost) || 0);
+  }, 0);
+}
+
+export {
+  FLOWER_OF_LIFE_LAYOUT,
+  FLOWER_OF_LIFE_NODES,
+  FLOWER_OF_LIFE_CONNECTIONS,
+  FLOWER_OF_LIFE_PETAL_GATES,
+  FLOWER_OF_LIFE_NODE_MAP,
+  FLOWER_OF_LIFE_DEPENDENT_MAP,
+  FLOWER_OF_LIFE_DEFAULT_PROGRESS,
+  evaluateGate,
+  computeAvailablePetalCount,
+  sumAllocatedCost,
+};
+
+export default {
+  FLOWER_OF_LIFE_LAYOUT,
+  FLOWER_OF_LIFE_NODES,
+  FLOWER_OF_LIFE_CONNECTIONS,
+  FLOWER_OF_LIFE_PETAL_GATES,
+  FLOWER_OF_LIFE_NODE_MAP,
+  FLOWER_OF_LIFE_DEPENDENT_MAP,
+  FLOWER_OF_LIFE_DEFAULT_PROGRESS,
+  evaluateGate,
+  computeAvailablePetalCount,
+  sumAllocatedCost,
+};

--- a/src/Delaford.vue
+++ b/src/Delaford.vue
@@ -248,6 +248,7 @@ import FriendListPane from './components/slots/FriendList.vue';
 import SettingsPane from './components/slots/Settings.vue';
 import LogoutPane from './components/slots/Logout.vue';
 import QuestsPane from './components/slots/Quests.vue';
+import FlowerOfLifePane from './components/passives/FlowerOfLifePane.vue';
 
 // Sub Vue components
 import ContextMenu from './components/sub/ContextMenu.vue';
@@ -280,6 +281,7 @@ const paneRegistry = {
   settings: SettingsPane,
   logout: LogoutPane,
   quests: QuestsPane,
+  flowerOfLife: FlowerOfLifePane,
 };
 
 const paneTitles = {
@@ -290,6 +292,7 @@ const paneTitles = {
   settings: 'Settings',
   logout: 'Logout',
   quests: 'Quests',
+  flowerOfLife: 'Flower of Life',
 };
 
 const DEFAULT_CHAT_PREVIEW = 'Welcome to Delaford.';
@@ -519,7 +522,12 @@ export default {
       this.screen = 'server-down';
     };
 
+    this.handleFlowerPaneOpen = () => {
+      this.openPane('flowerOfLife');
+    };
+
     bus.$on('show-sidebar', this.showSidebar);
+    bus.$on('flower-of-life:open', this.handleFlowerPaneOpen);
 
     // On logout, let's do a few things...
     bus.$on('player:logout', this.logout);
@@ -556,6 +564,8 @@ export default {
         this.quickbarFlashTimeout = null;
       }
     }
+
+    bus.$off('flower-of-life:open', this.handleFlowerPaneOpen);
 
     if (this.game && this.game.map && typeof this.game.map.destroy === 'function') {
       this.game.map.destroy();

--- a/src/components/passives/FlowerOfLifePane.vue
+++ b/src/components/passives/FlowerOfLifePane.vue
@@ -1,0 +1,696 @@
+<template>
+  <div class="flower-pane">
+    <div class="flower-pane__tree">
+      <FlowerOfLifeTree
+        :view-box="layout.viewBox"
+        :nodes="renderNodes"
+        :connections="renderConnections"
+        :selected-id="selectedNodeId"
+        @select="handleSelect"
+      />
+    </div>
+
+    <aside class="flower-pane__sidebar">
+      <section class="flower-pane__summary">
+        <header>Petal Ledger</header>
+        <div class="flower-pane__petal-meter">
+          <span class="flower-pane__petal-count">
+            <strong>{{ spentPetals }}</strong>
+            <span class="flower-pane__petal-label">spent</span>
+          </span>
+          <span class="flower-pane__petal-separator">/</span>
+          <span class="flower-pane__petal-count">
+            <strong>{{ petalSummary.total }}</strong>
+            <span class="flower-pane__petal-label">earned</span>
+          </span>
+        </div>
+        <p class="flower-pane__petal-available">
+          {{ availablePetals }} petal{{ availablePetals === 1 ? '' : 's' }} available
+        </p>
+      </section>
+
+      <section class="flower-pane__milestones">
+        <header>Milestones</header>
+        <ul>
+          <li
+            v-for="gate in petalGates"
+            :key="gate.id"
+            :class="{
+              'flower-pane__milestone': true,
+              'flower-pane__milestone--complete': gate.evaluation.achieved,
+            }"
+          >
+            <div class="flower-pane__milestone-header">
+              <span class="flower-pane__milestone-title">{{ gate.label }}</span>
+              <span class="flower-pane__milestone-status">
+                {{ gate.evaluation.achieved ? 'Claimed' : 'Locked' }}
+              </span>
+            </div>
+            <p class="flower-pane__milestone-description">{{ gate.description }}</p>
+            <div class="flower-pane__milestone-footer">
+              <span class="flower-pane__milestone-reward">+{{ gate.reward }} petal</span>
+              <template v-if="gate.evaluation.type === 'level'">
+                <span class="flower-pane__milestone-meta">
+                  Level {{ gate.evaluation.currentLevel || 1 }} / {{ gate.evaluation.requiredLevel }}
+                </span>
+              </template>
+              <template v-else-if="gate.supportsManual">
+                <label class="flower-pane__milestone-toggle">
+                  <input
+                    type="checkbox"
+                    :checked="gate.manualValue"
+                    @change="toggleManualGate(gate, $event.target.checked)"
+                  >
+                  <span>Mark complete</span>
+                </label>
+              </template>
+              <template v-else-if="gate.evaluation.reason">
+                <span class="flower-pane__milestone-meta">{{ gate.evaluation.reason }}</span>
+              </template>
+            </div>
+          </li>
+        </ul>
+      </section>
+
+      <section
+        v-if="selectedNode"
+        class="flower-pane__details"
+      >
+        <header class="flower-pane__details-header">
+          <div>
+            <h3>{{ selectedNode.label }}</h3>
+            <p class="flower-pane__details-summary">{{ selectedNode.summary }}</p>
+          </div>
+          <span class="flower-pane__details-cost">
+            Cost: {{ selectedNode.cost }} petal{{ selectedNode.cost === 1 ? '' : 's' }}
+          </span>
+        </header>
+        <p class="flower-pane__details-description">{{ selectedNode.description }}</p>
+        <ul class="flower-pane__details-rewards">
+          <li
+            v-for="reward in selectedNode.rewards"
+            :key="reward"
+          >{{ reward }}</li>
+        </ul>
+
+        <div class="flower-pane__requirements">
+          <h4>Requirements</h4>
+          <ul>
+            <li
+              v-for="requirement in selectedNode.gateStates"
+              :key="requirement.id"
+              :class="{
+                'flower-pane__requirement': true,
+                'flower-pane__requirement--met': requirement.achieved,
+              }"
+            >
+              <span class="flower-pane__requirement-label">{{ formatRequirement(requirement) }}</span>
+            </li>
+            <li
+              v-if="selectedNode.requires && selectedNode.requires.length"
+              :class="{
+                'flower-pane__requirement': true,
+                'flower-pane__requirement--met': selectedNode.prerequisitesMet,
+              }"
+            >
+              <span class="flower-pane__requirement-label">
+                Requires: {{ selectedNode.requires.map(id => nodeLabels[id] || id).join(', ') }}
+              </span>
+            </li>
+          </ul>
+        </div>
+
+        <div
+          v-if="selectedNode.blockedReason && !selectedNode.allocated"
+          class="flower-pane__hint"
+        >
+          {{ selectedNode.blockedReason }}
+        </div>
+
+        <div
+          v-if="!canRefundSelected && selectedNode.allocated && nodeDependents.length"
+          class="flower-pane__hint flower-pane__hint--warning"
+        >
+          Remove dependent nodes first: {{ nodeDependents.map(node => node.label).join(', ') }}
+        </div>
+
+        <div class="flower-pane__actions">
+          <button
+            type="button"
+            class="flower-pane__action"
+            :disabled="!canAllocateSelected"
+            @click="allocateSelected"
+          >
+            Allocate
+          </button>
+          <button
+            type="button"
+            class="flower-pane__action"
+            :disabled="!canRefundSelected"
+            @click="refundSelected"
+          >
+            Refund
+          </button>
+        </div>
+      </section>
+
+      <footer class="flower-pane__footer">
+        <button
+          type="button"
+          class="flower-pane__reset"
+          :disabled="!canReset"
+          @click="resetTree"
+        >
+          Reset Flower
+        </button>
+      </footer>
+    </aside>
+  </div>
+</template>
+
+<script>
+import { mapActions } from 'vuex';
+import FlowerOfLifeTree from './FlowerOfLifeTree.vue';
+import {
+  FLOWER_OF_LIFE_LAYOUT,
+  FLOWER_OF_LIFE_NODES,
+  FLOWER_OF_LIFE_CONNECTIONS,
+  FLOWER_OF_LIFE_NODE_MAP,
+  FLOWER_OF_LIFE_DEPENDENT_MAP,
+  FLOWER_OF_LIFE_PETAL_GATES,
+  FLOWER_OF_LIFE_DEFAULT_PROGRESS,
+  computeAvailablePetalCount,
+  evaluateGate,
+  sumAllocatedCost,
+} from 'shared/passives/flower-of-life';
+
+export default {
+  name: 'FlowerOfLifePane',
+  components: {
+    FlowerOfLifeTree,
+  },
+  props: {
+    game: {
+      type: Object,
+      required: true,
+    },
+  },
+  data() {
+    return {
+      selectedNodeId: 'heart-of-bloom',
+      layout: FLOWER_OF_LIFE_LAYOUT,
+    };
+  },
+  computed: {
+    player() {
+      return this.game && this.game.player ? this.game.player : {};
+    },
+    flowerProgress() {
+      const passives = this.$store && this.$store.state && this.$store.state.passives;
+      if (!passives || !passives.flowerOfLife) {
+        return FLOWER_OF_LIFE_DEFAULT_PROGRESS;
+      }
+      return passives.flowerOfLife;
+    },
+    allocatedSet() {
+      return new Set(this.flowerProgress.allocatedNodes || []);
+    },
+    petalSummary() {
+      return computeAvailablePetalCount(this.player, this.flowerProgress);
+    },
+    spentPetals() {
+      return sumAllocatedCost(this.flowerProgress.allocatedNodes || []);
+    },
+    availablePetals() {
+      return Math.max(0, this.petalSummary.total - this.spentPetals);
+    },
+    renderNodes() {
+      return FLOWER_OF_LIFE_NODES.map((node) => {
+        const angle = (node.angle || 0) * (Math.PI / 180);
+        const radius = (node.ring || 0) * this.layout.ringSpacing;
+        const x = this.layout.center + (radius * Math.cos(angle));
+        const y = this.layout.center - (radius * Math.sin(angle));
+        const displayRadius = this.layout.radii[node.type] || this.layout.radii.default;
+        const allocated = this.allocatedSet.has(node.id);
+        const cost = Math.max(0, Number(node.cost) || 0);
+        const gateStates = (node.gates || []).map(gate => evaluateGate(gate, {
+          player: this.player,
+          progress: this.flowerProgress,
+        }));
+        const gatesSatisfied = gateStates.every(state => state.achieved);
+        const prerequisitesMet = (node.requires || []).every(req => this.allocatedSet.has(req));
+        const hasPetals = this.availablePetals >= cost;
+        const available = !allocated && prerequisitesMet && gatesSatisfied && hasPetals;
+        const locked = !allocated && (!prerequisitesMet || !gatesSatisfied);
+        const unmetGate = gateStates.find(state => !state.achieved);
+        let blockedReason = null;
+        if (!prerequisitesMet) {
+          blockedReason = 'Allocate prerequisite nodes first.';
+        } else if (unmetGate && !unmetGate.achieved) {
+          blockedReason = unmetGate.reason;
+        } else if (!allocated && !hasPetals) {
+          blockedReason = 'Earn additional petals to allocate this node.';
+        }
+        const shortLabel = node.label.replace(/^Petal of\s+/i, '').replace(/^Bloom\s+/i, '').trim() || node.label;
+        return {
+          ...node,
+          x,
+          y,
+          displayRadius,
+          allocated,
+          available,
+          locked,
+          gateStates,
+          prerequisitesMet,
+          blockedReason,
+          insufficientPetals: !allocated && prerequisitesMet && gatesSatisfied && !hasPetals,
+          cost,
+          shortLabel,
+        };
+      });
+    },
+    renderNodesMap() {
+      return this.renderNodes.reduce((acc, node) => {
+        acc[node.id] = node;
+        return acc;
+      }, {});
+    },
+    renderConnections() {
+      return FLOWER_OF_LIFE_CONNECTIONS.map((connection) => {
+        const from = this.renderNodesMap[connection.from];
+        const to = this.renderNodesMap[connection.to];
+        if (!from || !to) {
+          return null;
+        }
+        const active = from.allocated && to.allocated;
+        const reachable = (from.allocated || from.available) && (to.allocated || to.available);
+        return {
+          ...connection,
+          from,
+          to,
+          active,
+          reachable,
+        };
+      }).filter(Boolean);
+    },
+    selectedNode() {
+      if (this.renderNodesMap[this.selectedNodeId]) {
+        return this.renderNodesMap[this.selectedNodeId];
+      }
+      return this.renderNodes[0] || null;
+    },
+    nodeLabels() {
+      return Object.keys(FLOWER_OF_LIFE_NODE_MAP).reduce((acc, key) => {
+        const node = FLOWER_OF_LIFE_NODE_MAP[key];
+        acc[key] = node && node.label ? node.label : key;
+        return acc;
+      }, {});
+    },
+    nodeDependents() {
+      if (!this.selectedNode) {
+        return [];
+      }
+      const dependents = FLOWER_OF_LIFE_DEPENDENT_MAP[this.selectedNode.id] || [];
+      return dependents
+        .filter(id => this.allocatedSet.has(id))
+        .map(id => FLOWER_OF_LIFE_NODE_MAP[id])
+        .filter(Boolean);
+    },
+    canAllocateSelected() {
+      const node = this.selectedNode;
+      if (!node) {
+        return false;
+      }
+      return node.available;
+    },
+    canRefundSelected() {
+      const node = this.selectedNode;
+      if (!node || !node.allocated) {
+        return false;
+      }
+      const dependents = FLOWER_OF_LIFE_DEPENDENT_MAP[node.id] || [];
+      return dependents.every(id => !this.allocatedSet.has(id));
+    },
+    canReset() {
+      return (this.flowerProgress.allocatedNodes || []).length > 0;
+    },
+    petalGates() {
+      return FLOWER_OF_LIFE_PETAL_GATES.map((gate) => {
+        const evaluation = evaluateGate(gate, {
+          player: this.player,
+          progress: this.flowerProgress,
+        });
+        const manualValue = Boolean(this.flowerProgress.manualMilestones && this.flowerProgress.manualMilestones[gate.id]);
+        return {
+          ...gate,
+          evaluation,
+          supportsManual: evaluation.manual,
+          manualValue,
+        };
+      });
+    },
+  },
+  methods: {
+    ...mapActions([
+      'allocateFlowerNode',
+      'refundFlowerNode',
+      'resetFlowerOfLife',
+      'setFlowerManualMilestone',
+    ]),
+    formatRequirement(requirement) {
+      if (!requirement) {
+        return '';
+      }
+      if (!requirement.achieved && requirement.reason) {
+        return requirement.reason;
+      }
+      if (requirement.type === 'level' && requirement.requiredLevel) {
+        return `Level ${requirement.requiredLevel}+`;
+      }
+      if (requirement.type === 'quest') {
+        return 'Quest complete';
+      }
+      if (requirement.type === 'manual') {
+        return 'Marked complete';
+      }
+      return 'Unlocked';
+    },
+    handleSelect(nodeId) {
+      if (nodeId) {
+        this.selectedNodeId = nodeId;
+      }
+    },
+    allocateSelected() {
+      if (!this.canAllocateSelected || !this.selectedNode) {
+        return;
+      }
+      this.allocateFlowerNode({ nodeId: this.selectedNode.id });
+    },
+    refundSelected() {
+      if (!this.canRefundSelected || !this.selectedNode) {
+        return;
+      }
+      this.refundFlowerNode({ nodeId: this.selectedNode.id });
+    },
+    resetTree() {
+      if (!this.canReset) {
+        return;
+      }
+      this.resetFlowerOfLife();
+    },
+    toggleManualGate(gate, value) {
+      this.setFlowerManualMilestone({ gateId: gate.id, value });
+    },
+  },
+};
+</script>
+
+<style lang="scss" scoped>
+.flower-pane {
+  display: grid;
+  grid-template-columns: minmax(0, 2fr) minmax(300px, 1fr);
+  gap: 1.5rem;
+  color: #f5f5f5;
+}
+
+.flower-pane__tree {
+  min-height: 420px;
+}
+
+.flower-pane__sidebar {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  font-family: "GameFont", sans-serif;
+}
+
+.flower-pane__summary,
+.flower-pane__milestones,
+.flower-pane__details,
+.flower-pane__footer {
+  background: rgba(12, 12, 24, 0.85);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 12px;
+  padding: 1rem;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.04);
+}
+
+.flower-pane__summary header,
+.flower-pane__milestones header,
+.flower-pane__details-header h3 {
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.9rem;
+  margin-bottom: 0.5rem;
+  color: #ffe082;
+}
+
+.flower-pane__petal-meter {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 1rem;
+}
+
+.flower-pane__petal-count {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.flower-pane__petal-count strong {
+  font-size: 1.6rem;
+  color: #ffd54f;
+}
+
+.flower-pane__petal-label {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  opacity: 0.75;
+}
+
+.flower-pane__petal-separator {
+  font-size: 1.2rem;
+  opacity: 0.6;
+}
+
+.flower-pane__petal-available {
+  margin-top: 0.5rem;
+  font-size: 0.85rem;
+  color: rgba(255, 255, 255, 0.75);
+}
+
+.flower-pane__milestones ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.flower-pane__milestone {
+  padding: 0.75rem;
+  border-radius: 10px;
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.flower-pane__milestone--complete {
+  border-color: rgba(139, 195, 74, 0.6);
+  background: rgba(139, 195, 74, 0.1);
+}
+
+.flower-pane__milestone-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  font-size: 0.85rem;
+}
+
+.flower-pane__milestone-title {
+  font-weight: 600;
+}
+
+.flower-pane__milestone-status {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: rgba(255, 255, 255, 0.6);
+}
+
+.flower-pane__milestone-description {
+  margin: 0.25rem 0 0.5rem;
+  font-size: 0.75rem;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.flower-pane__milestone-footer {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 0.75rem;
+}
+
+.flower-pane__milestone-reward {
+  color: #ffd54f;
+  font-weight: 600;
+}
+
+.flower-pane__milestone-meta {
+  color: rgba(255, 255, 255, 0.6);
+}
+
+.flower-pane__milestone-toggle {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  cursor: pointer;
+  font-size: 0.75rem;
+}
+
+.flower-pane__milestone-toggle input {
+  accent-color: #ffd54f;
+}
+
+.flower-pane__details-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1rem;
+}
+
+.flower-pane__details-summary {
+  margin: 0;
+  font-size: 0.85rem;
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.flower-pane__details-cost {
+  font-size: 0.8rem;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.flower-pane__details-description {
+  font-size: 0.8rem;
+  color: rgba(255, 255, 255, 0.75);
+  margin: 0.75rem 0;
+}
+
+.flower-pane__details-rewards {
+  list-style: disc;
+  margin: 0 0 0 1.25rem;
+  padding: 0;
+  font-size: 0.78rem;
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.flower-pane__requirements h4 {
+  margin: 1rem 0 0.5rem;
+  text-transform: uppercase;
+  font-size: 0.75rem;
+  letter-spacing: 0.05em;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.flower-pane__requirements ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.flower-pane__requirement {
+  font-size: 0.75rem;
+  color: rgba(255, 255, 255, 0.6);
+}
+
+.flower-pane__requirement--met {
+  color: #8bc34a;
+}
+
+.flower-pane__hint {
+  margin-top: 0.75rem;
+  font-size: 0.75rem;
+  color: rgba(255, 255, 255, 0.75);
+  padding: 0.5rem 0.75rem;
+  background: rgba(255, 255, 255, 0.05);
+  border-radius: 6px;
+}
+
+.flower-pane__hint--warning {
+  color: #ffab91;
+  background: rgba(255, 171, 145, 0.1);
+}
+
+.flower-pane__actions {
+  margin-top: 1rem;
+  display: flex;
+  gap: 0.75rem;
+}
+
+.flower-pane__action {
+  flex: 1;
+  padding: 0.6rem 0.75rem;
+  border: none;
+  border-radius: 6px;
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  background: linear-gradient(135deg, rgba(255, 215, 64, 0.9), rgba(255, 171, 64, 0.9));
+  color: #1a1a1a;
+  cursor: pointer;
+  font-weight: 600;
+  transition: transform 0.15s ease, filter 0.15s ease;
+}
+
+.flower-pane__action:disabled {
+  cursor: not-allowed;
+  filter: grayscale(0.7);
+  background: rgba(255, 255, 255, 0.1);
+  color: rgba(255, 255, 255, 0.5);
+}
+
+.flower-pane__action:not(:disabled):hover {
+  transform: translateY(-1px);
+}
+
+.flower-pane__footer {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.flower-pane__reset {
+  padding: 0.5rem 0.75rem;
+  border-radius: 6px;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  background: rgba(255, 255, 255, 0.08);
+  color: rgba(255, 255, 255, 0.85);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  cursor: pointer;
+  transition: background 0.15s ease, color 0.15s ease;
+}
+
+.flower-pane__reset:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.flower-pane__reset:not(:disabled):hover {
+  background: rgba(255, 255, 255, 0.15);
+}
+
+@media (max-width: 1024px) {
+  .flower-pane {
+    grid-template-columns: 1fr;
+  }
+
+  .flower-pane__tree {
+    max-width: 480px;
+    margin: 0 auto;
+  }
+}
+</style>

--- a/src/components/passives/FlowerOfLifeTree.vue
+++ b/src/components/passives/FlowerOfLifeTree.vue
@@ -1,0 +1,211 @@
+<template>
+  <div class="flower-tree">
+    <svg
+      class="flower-tree__svg"
+      :viewBox="`0 0 ${viewBox} ${viewBox}`"
+      role="presentation"
+    >
+      <g class="flower-tree__connections">
+        <line
+          v-for="connection in connections"
+          :key="connection.id"
+          :x1="connection.from.x"
+          :y1="connection.from.y"
+          :x2="connection.to.x"
+          :y2="connection.to.y"
+          :class="connectionClass(connection)"
+        />
+      </g>
+
+      <g class="flower-tree__nodes">
+        <g
+          v-for="node in nodes"
+          :key="node.id"
+          :class="nodeClass(node)"
+          :transform="`translate(${node.x}, ${node.y})`"
+        >
+          <circle
+            class="flower-tree__node-hitbox"
+            :r="node.displayRadius + 14"
+            @click="() => onNodeClick(node)"
+            @mouseenter="() => onNodeHover(node)"
+            @mouseleave="onNodeLeave"
+          />
+          <circle
+            class="flower-tree__node-bg"
+            :r="node.displayRadius"
+          />
+          <circle
+            class="flower-tree__node-core"
+            :r="node.displayRadius - 4"
+          />
+          <text
+            class="flower-tree__node-label"
+            dominant-baseline="middle"
+            text-anchor="middle"
+            :y="node.displayRadius + 18"
+          >
+            {{ node.shortLabel }}
+          </text>
+        </g>
+      </g>
+    </svg>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'FlowerOfLifeTree',
+  props: {
+    nodes: {
+      type: Array,
+      default: () => [],
+    },
+    connections: {
+      type: Array,
+      default: () => [],
+    },
+    viewBox: {
+      type: Number,
+      default: 640,
+    },
+    selectedId: {
+      type: String,
+      default: null,
+    },
+  },
+  methods: {
+    onNodeClick(node) {
+      this.$emit('select', node.id);
+    },
+    onNodeHover(node) {
+      this.$emit('hover', node.id);
+    },
+    onNodeLeave() {
+      this.$emit('hover', null);
+    },
+    nodeClass(node) {
+      return {
+        'flower-tree__node': true,
+        'flower-tree__node--allocated': node.allocated,
+        'flower-tree__node--available': node.available,
+        'flower-tree__node--locked': node.locked,
+        'flower-tree__node--selected': node.id === this.selectedId,
+        'flower-tree__node--keystone': node.type === 'keystone',
+        'flower-tree__node--major': node.type === 'major',
+        'flower-tree__node--notable': node.type === 'notable',
+      };
+    },
+    connectionClass(connection) {
+      return {
+        'flower-tree__connection': true,
+        'flower-tree__connection--active': connection.active,
+        'flower-tree__connection--reachable': connection.reachable,
+      };
+    },
+  },
+};
+</script>
+
+<style lang="scss" scoped>
+.flower-tree {
+  width: 100%;
+  aspect-ratio: 1 / 1;
+  background: radial-gradient(circle at center, rgba(255, 255, 255, 0.08) 0%, rgba(0, 0, 0, 0.6) 70%);
+  border-radius: 50%;
+  position: relative;
+  overflow: hidden;
+}
+
+.flower-tree__svg {
+  width: 100%;
+  height: 100%;
+}
+
+.flower-tree__connections line {
+  stroke: rgba(255, 255, 255, 0.25);
+  stroke-width: 3;
+  transition: stroke 0.2s ease, stroke-width 0.2s ease;
+}
+
+.flower-tree__connection--active {
+  stroke: #ffe082;
+  stroke-width: 4;
+}
+
+.flower-tree__connection--reachable:not(.flower-tree__connection--active) {
+  stroke: rgba(255, 224, 130, 0.6);
+}
+
+.flower-tree__nodes {
+  cursor: pointer;
+}
+
+.flower-tree__node {
+  transition: transform 0.2s ease, filter 0.2s ease;
+}
+
+.flower-tree__node-hitbox {
+  fill: transparent;
+}
+
+.flower-tree__node-bg {
+  fill: rgba(15, 15, 30, 0.9);
+  stroke: rgba(255, 255, 255, 0.25);
+  stroke-width: 2;
+  transition: stroke 0.2s ease, fill 0.2s ease;
+}
+
+.flower-tree__node-core {
+  fill: rgba(255, 255, 255, 0.05);
+  transition: fill 0.2s ease;
+}
+
+.flower-tree__node-label {
+  fill: rgba(255, 255, 255, 0.85);
+  font-size: 12px;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  pointer-events: none;
+}
+
+.flower-tree__node--allocated .flower-tree__node-bg {
+  stroke: #ffa726;
+  fill: rgba(255, 171, 64, 0.4);
+}
+
+.flower-tree__node--allocated .flower-tree__node-core {
+  fill: rgba(255, 213, 79, 0.35);
+}
+
+.flower-tree__node--available:not(.flower-tree__node--allocated) .flower-tree__node-bg {
+  stroke: #8bc34a;
+  fill: rgba(139, 195, 74, 0.25);
+}
+
+.flower-tree__node--available:not(.flower-tree__node--allocated) .flower-tree__node-core {
+  fill: rgba(139, 195, 74, 0.3);
+}
+
+.flower-tree__node--locked .flower-tree__node-bg {
+  stroke: rgba(255, 255, 255, 0.15);
+  fill: rgba(0, 0, 0, 0.35);
+}
+
+.flower-tree__node--selected {
+  filter: drop-shadow(0 0 8px rgba(255, 215, 64, 0.6));
+}
+
+.flower-tree__node--keystone .flower-tree__node-bg {
+  stroke-width: 3;
+}
+
+.flower-tree__node--major .flower-tree__node-bg {
+  stroke-dasharray: 8 4;
+}
+
+.flower-tree__node:hover .flower-tree__node-bg,
+.flower-tree__node--available .flower-tree__node-bg {
+  stroke-width: 3;
+}
+</style>

--- a/src/store.js
+++ b/src/store.js
@@ -1,8 +1,27 @@
 import Vue from 'vue';
 import Vuex from 'vuex';
 import createPersistedState from 'vuex-persistedstate';
+import {
+  FLOWER_OF_LIFE_DEFAULT_PROGRESS,
+  FLOWER_OF_LIFE_NODE_MAP,
+  FLOWER_OF_LIFE_DEPENDENT_MAP,
+} from 'shared/passives/flower-of-life';
 
 Vue.use(Vuex);
+
+const clone = (value) => JSON.parse(JSON.stringify(value));
+
+const createFlowerOfLifeState = () => clone(FLOWER_OF_LIFE_DEFAULT_PROGRESS);
+
+const ensureFlowerState = (state) => {
+  if (!state.passives) {
+    Vue.set(state, 'passives', { flowerOfLife: createFlowerOfLifeState() });
+  } else if (!state.passives.flowerOfLife) {
+    Vue.set(state.passives, 'flowerOfLife', createFlowerOfLifeState());
+  }
+
+  return state.passives.flowerOfLife;
+};
 
 export default new Vuex.Store({
   plugins: [createPersistedState()],
@@ -17,12 +36,17 @@ export default new Vuex.Store({
       label: '',
       object: '',
     },
+    passives: {
+      flowerOfLife: createFlowerOfLifeState(),
+    },
   },
   getters: {
     account: (state) => state.account,
     action: (state) => state.action,
     guestAccount: (state) => state.guestAccount,
     rememberMe: (state) => state.rememberMe,
+    flowerOfLifeState: (state) => ensureFlowerState(state),
+    flowerOfLifeAllocated: (state) => ensureFlowerState(state).allocatedNodes,
   },
   mutations: {
     REMEMBER_DEV_ACCOUNT: (state, payload) => {
@@ -39,6 +63,33 @@ export default new Vuex.Store({
     SET_GUEST_ACCOUNT: (state, payload) => {
       state.guestAccount = payload;
     },
+    RESET_FLOWER_OF_LIFE: (state, timestamp) => {
+      const next = createFlowerOfLifeState();
+      next.lastResetAt = timestamp || Date.now();
+      if (!state.passives) {
+        Vue.set(state, 'passives', { flowerOfLife: next });
+        return;
+      }
+      Vue.set(state.passives, 'flowerOfLife', next);
+    },
+    ALLOCATE_FLOWER_OF_LIFE_NODE: (state, nodeId) => {
+      const flower = ensureFlowerState(state);
+      if (!flower.allocatedNodes.includes(nodeId)) {
+        flower.allocatedNodes.push(nodeId);
+      }
+    },
+    REFUND_FLOWER_OF_LIFE_NODE: (state, nodeId) => {
+      const flower = ensureFlowerState(state);
+      const updated = flower.allocatedNodes.filter(id => id !== nodeId);
+      Vue.set(flower, 'allocatedNodes', updated);
+    },
+    SET_FLOWER_OF_LIFE_MANUAL_MILESTONE: (state, { gateId, value }) => {
+      const flower = ensureFlowerState(state);
+      if (!flower.manualMilestones) {
+        Vue.set(flower, 'manualMilestones', {});
+      }
+      Vue.set(flower.manualMilestones, gateId, Boolean(value));
+    },
   },
   actions: {
     setAction: (context, payload) => {
@@ -52,6 +103,48 @@ export default new Vuex.Store({
     },
     rememberDevAccount: (context, payload) => {
       context.commit('REMEMBER_DEV_ACCOUNT', payload);
+    },
+    allocateFlowerNode: ({ state, commit }, { nodeId }) => {
+      if (!nodeId || !FLOWER_OF_LIFE_NODE_MAP[nodeId]) {
+        return false;
+      }
+
+      const flower = ensureFlowerState(state);
+      if (flower.allocatedNodes.includes(nodeId)) {
+        return false;
+      }
+
+      const node = FLOWER_OF_LIFE_NODE_MAP[nodeId];
+      if (Array.isArray(node.requires)) {
+        const missing = node.requires.some(req => !flower.allocatedNodes.includes(req));
+        if (missing) {
+          return false;
+        }
+      }
+
+      commit('ALLOCATE_FLOWER_OF_LIFE_NODE', nodeId);
+      return true;
+    },
+    refundFlowerNode: ({ state, commit }, { nodeId }) => {
+      const flower = ensureFlowerState(state);
+      if (!nodeId || !flower.allocatedNodes.includes(nodeId)) {
+        return false;
+      }
+
+      const dependents = FLOWER_OF_LIFE_DEPENDENT_MAP[nodeId] || [];
+      const blocked = dependents.some(dep => flower.allocatedNodes.includes(dep));
+      if (blocked) {
+        return false;
+      }
+
+      commit('REFUND_FLOWER_OF_LIFE_NODE', nodeId);
+      return true;
+    },
+    resetFlowerOfLife: ({ commit }) => {
+      commit('RESET_FLOWER_OF_LIFE', Date.now());
+    },
+    setFlowerManualMilestone: ({ commit }, payload) => {
+      commit('SET_FLOWER_OF_LIFE_MANUAL_MILESTONE', payload);
     },
   },
 });


### PR DESCRIPTION
## Summary
- add shared Flower of Life passive tree schema, gating logic, and cost helpers
- extend the store with Flower of Life state, mutations, and actions
- build Flower of Life pane with SVG tree renderer plus milestone controls and hook it into the HUD

## Testing
- npm run lint *(fails: vue-cli-service not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68fd68d3a88c8321ad46d26b2bf0bd7f