### PR TITLE
Redesign pane layout and chat overlay

### DIFF
--- a/src/assets/scss/abstracts/_breakpoints.scss
+++ b/src/assets/scss/abstracts/_breakpoints.scss
@@ -1,0 +1,32 @@
+@use 'sass:string';
+
+$breakpoints: (
+  'mobile': 0,
+  'tablet': 768px,
+  'desktop': 1200px,
+);
+
+@function breakpoint-value($name) {
+  @if map-has-key($breakpoints, $name) {
+    @return map-get($breakpoints, $name);
+  }
+  @error 'Unknown breakpoint: '#{$name};
+}
+
+@mixin media($query) {
+  $operator: string.slice($query, 1, 2);
+  $name: string.slice($query, 3);
+  $value: breakpoint-value($name);
+
+  @if $operator == '>=' {
+    @media (min-width: $value) {
+      @content;
+    }
+  } @else if $operator == '<=' {
+    @media (max-width: if($value == 0, 0px, $value - 0.02px)) {
+      @content;
+    }
+  } @else {
+    @error 'Unsupported media query operator: '#{$operator};
+  }
+}

--- a/src/assets/scss/abstracts/_mixins.scss
+++ b/src/assets/scss/abstracts/_mixins.scss
@@ -1,0 +1,12 @@
+@use 'sass:math';
+
+@mixin fluid-size($property, $min, $max, $viewport-min: 320px, $viewport-max: 1440px) {
+  #{$property}: clamp($min, calc(#{$min} + (#{$max} - #{$min}) * ((100vw - #{$viewport-min}) / (#{$viewport-max} - #{$viewport-min}))), $max);
+}
+
+@mixin glass-panel($background: rgba(18, 24, 40, 0.78)) {
+  background: $background;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: 0 18px 32px rgba(0, 0, 0, 0.45);
+  backdrop-filter: blur(18px);
+}

--- a/src/assets/scss/abstracts/_tokens.scss
+++ b/src/assets/scss/abstracts/_tokens.scss
@@ -1,0 +1,38 @@
+:root {
+  --color-bg-primary: #0f111a;
+  --color-bg-surface: rgba(20, 24, 36, 0.92);
+  --color-bg-surface-muted: rgba(12, 15, 25, 0.9);
+  --color-border-subtle: rgba(255, 255, 255, 0.06);
+  --color-border-strong: rgba(255, 255, 255, 0.18);
+  --color-text-primary: #f5f5f5;
+  --color-text-secondary: rgba(255, 255, 255, 0.76);
+  --color-accent: #4cb3ff;
+  --color-accent-strong: #8ad6ff;
+  --color-danger: #ff6b6b;
+  --color-success: #7dd97c;
+
+  --font-size-base: clamp(14px, 1.1vw, 16px);
+  --font-size-sm: clamp(12px, 1vw, 14px);
+  --font-size-lg: clamp(16px, 1.3vw, 18px);
+
+  --space-xs: clamp(4px, 0.5vw, 6px);
+  --space-sm: clamp(6px, 0.6vw, 8px);
+  --space-md: clamp(10px, 0.8vw, 14px);
+  --space-lg: clamp(14px, 1vw, 18px);
+  --space-xl: clamp(20px, 1.4vw, 28px);
+  --space-2xl: clamp(28px, 2vw, 40px);
+
+  --radius-sm: 6px;
+  --radius-md: 12px;
+  --radius-lg: 18px;
+
+  --shadow-soft: 0 12px 24px rgba(0, 0, 0, 0.35);
+  --shadow-strong: 0 28px 48px rgba(0, 0, 0, 0.65);
+}
+
+body {
+  font-family: 'GameFont', 'Segoe UI', sans-serif;
+  font-size: var(--font-size-base);
+  background: var(--color-bg-primary);
+  color: var(--color-text-primary);
+}

--- a/src/assets/scss/base/_globals.scss
+++ b/src/assets/scss/base/_globals.scss
@@ -1,0 +1,21 @@
+@use '../abstracts/tokens' as *;
+
+*, *::before, *::after {
+  box-sizing: border-box;
+}
+
+html, body {
+  margin: 0;
+  padding: 0;
+  min-height: 100%;
+  background: var(--color-bg-primary);
+  color: var(--color-text-primary);
+}
+
+a {
+  color: var(--color-accent);
+}
+
+button, input {
+  font: inherit;
+}

--- a/src/assets/scss/elements/form.scss
+++ b/src/assets/scss/elements/form.scss
@@ -1,18 +1,26 @@
-@use 'sass:color';
-@use './colors' as *;
+@use '@/assets/scss/abstracts/tokens' as *;
 
 .button {
-  $background_color: grey;
-  $text_color: color.adjust(orange, $lightness: 5%);
-
-  background-color: color.adjust($background_color, $lightness: -5%);
-  border: 2px solid color.adjust($background_color, $lightness: -25%);
-  text-shadow: 1px 1px 0 #000;
-  outline: none;
-  cursor: pointer;
-  padding: 1px 6px 0 6px;
-  color: $text_color;
-  margin: 0;
-  font-size: 15px;
+  appearance: none;
+  border-radius: var(--radius-sm);
+  padding: var(--space-xs) var(--space-md);
+  border: 1px solid var(--color-border-strong);
+  background: linear-gradient(180deg, rgba(80, 110, 168, 0.85), rgba(40, 62, 112, 0.95));
+  color: var(--color-text-primary);
+  text-shadow: 0 1px 0 rgba(0, 0, 0, 0.45);
   font-family: 'UIFont', serif;
+  font-size: var(--font-size-sm);
+  cursor: pointer;
+  transition: transform 140ms ease-out, box-shadow 140ms ease-out, border-color 140ms ease-out;
+
+  &:hover {
+    transform: translateY(-1px);
+    border-color: rgba(255, 255, 255, 0.45);
+    box-shadow: var(--shadow-soft);
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--color-accent-strong);
+    outline-offset: 2px;
+  }
 }

--- a/src/assets/scss/main.scss
+++ b/src/assets/scss/main.scss
@@ -1,7 +1,13 @@
-// Game Stylesheet
 @charset 'utf-8';
 
-// Import SCSS
-@use './typography/fonts' as *;
-@use './typography/sizes' as *;
-@use './elements/form' as *;
+@use './abstracts/tokens';
+@use './abstracts/breakpoints';
+@use './abstracts/mixins';
+@use './base/globals';
+@use './typography/fonts';
+@use './typography/sizes';
+@use './elements/form';
+
+:root {
+  --chat-width: clamp(260px, 22vw, 360px);
+}

--- a/src/components/Chatbox.vue
+++ b/src/components/Chatbox.vue
@@ -1,211 +1,533 @@
 <template>
-  <div
+  <section
     class="chatbox"
-    @click="chatboxClicked"
+    :class="chatboxClasses"
+    @mouseenter="$emit('hover-state', true)"
+    @mouseleave="$emit('hover-state', false)"
+    @click.stop="focusInput"
   >
+    <header class="chatbox__header">
+      <div class="chatbox__meta">
+        <h2 class="chatbox__title">Chat</h2>
+        <p
+          v-if="showCountdown"
+          class="chatbox__countdown"
+        >
+          Hiding in {{ countdownLabel }}
+        </p>
+      </div>
+      <div class="chatbox__actions">
+        <span
+          v-if="collapsed && unreadCount > 0"
+          class="chatbox__badge"
+          aria-live="polite"
+        >
+          {{ unreadCount }}
+        </span>
+        <button
+          class="chatbox__pin"
+          type="button"
+          @click="$emit('toggle-pin')"
+        >
+          {{ pinned ? 'Unpin' : 'Pin' }}
+        </button>
+      </div>
+    </header>
+
     <div
-      id="chat"
-      readonly
+      ref="messageList"
+      class="chatbox__messages"
     >
-      <div
-        v-for="(chat, i) in chatbox"
-        :key="i"
-        class="message"
-        v-html="showChatMessage(chat)"
-      />
+      <ul class="chatbox__list">
+        <li
+          v-for="(message, index) in messages"
+          :key="`${message.timestamp}-${index}`"
+          class="chatbox__message"
+        >
+          <span
+            v-if="message.username"
+            class="chatbox__username"
+          >
+            {{ message.username }}:
+          </span>
+          <span
+            class="chatbox__text"
+            v-html="message.display"
+          />
+          <span class="chatbox__time">{{ message.displayTime }}</span>
+        </li>
+      </ul>
     </div>
 
-    <input
-      v-model="said"
-      autocomplete="off"
-      maxlength="50"
-      type="text"
-      class="typing"
-      @keydown.enter="sendMessage"
+    <form
+      class="chatbox__form"
+      @submit.prevent="sendMessage"
     >
-  </div>
+      <input
+        ref="input"
+        v-model="said"
+        class="chatbox__input"
+        type="text"
+        autocomplete="off"
+        maxlength="120"
+        placeholder="Say something..."
+        @focus="handleFocus"
+        @blur="handleBlur"
+      >
+      <button
+        class="chatbox__submit"
+        type="submit"
+      >
+        Send
+      </button>
+    </form>
+  </section>
 </template>
 
 <script>
 import Socket from '../core/utilities/socket';
 import bus from '../core/utilities/bus';
 
+const formatTime = (timestamp) => {
+  const date = new Date(timestamp);
+  return date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+};
+
+const normaliseIncoming = (incoming) => {
+  if (Object.hasOwnProperty.call(incoming, 'text')) {
+    return incoming;
+  }
+  if (incoming && incoming.data) {
+    if (incoming.data.data) {
+      return incoming.data.data;
+    }
+    return incoming.data;
+  }
+  return incoming;
+};
+
 export default {
+  name: 'Chatbox',
   props: {
     game: {
       type: Object,
       required: true,
     },
+    layoutMode: {
+      type: String,
+      default: 'desktop',
+    },
+    pinned: {
+      type: Boolean,
+      default: false,
+    },
+    collapsed: {
+      type: Boolean,
+      default: false,
+    },
+    unreadCount: {
+      type: Number,
+      default: 0,
+    },
+    autoHideSeconds: {
+      type: Number,
+      default: 0,
+    },
   },
+  emits: ['message-appended', 'toggle-pin', 'hover-state', 'countdown-complete'],
   data() {
     return {
       said: '',
-      chatbox: [
+      messages: [
         {
           type: 'normal',
           text: 'Welcome to Delaford.',
+          username: '',
+          color: '#1D56F2',
+          timestamp: Date.now(),
+          display: 'Welcome to Delaford.',
+          displayTime: formatTime(Date.now()),
         },
       ],
+      hasFocus: false,
+      countdownRemaining: 0,
+      countdownTimer: null,
     };
   },
+  computed: {
+    chatboxClasses() {
+      return [
+        `chatbox--${this.layoutMode}`,
+        {
+          'chatbox--pinned': this.pinned,
+          'chatbox--collapsed': this.collapsed,
+        },
+      ];
+    },
+    showCountdown() {
+      return !this.pinned && !this.collapsed && this.countdownRemaining > 0;
+    },
+    countdownLabel() {
+      return `${this.countdownRemaining}s`;
+    },
+  },
+  watch: {
+    collapsed: {
+      immediate: true,
+      handler(value) {
+        if (!value && !this.pinned && this.autoHideSeconds > 0) {
+          this.startCountdown();
+        } else {
+          this.stopCountdown();
+        }
+      },
+    },
+    pinned(newValue) {
+      if (newValue) {
+        this.stopCountdown();
+      } else if (!this.collapsed && this.autoHideSeconds > 0) {
+        this.startCountdown();
+      }
+    },
+  },
   created() {
-    bus.$on('player:say', (data) => this.pipeline(data));
+    this.messageHandler = (data) => this.pipeline(data);
+    bus.$on('player:say', this.messageHandler);
+    bus.$on('item:examine', this.messageHandler);
   },
   mounted() {
-    bus.$on('item:examine', (data) => this.pipeline(data));
+    this.scrollToBottom();
+  },
+  beforeDestroy() {
+    bus.$off('player:say', this.messageHandler);
+    bus.$off('item:examine', this.messageHandler);
+    this.stopCountdown();
   },
   methods: {
-    /**
-     * Transfer messages from other components to chatbox
-     *
-     * @param {object} data The message to add
-     */
     pipeline(incoming) {
-      // We have three different types of messages.
-      // 1. Chat message - it has `text` key/value (from server)
-      // 2. Chat message from action - incoming.data (from client)
-      // 3. Examing text from server - incoming.data.data (from server)
-      const {
-        text, type, username,
-      } = Object.hasOwnProperty.call(incoming, 'text') ? incoming : (incoming.data.data || incoming.data);
-
-      // What we'll be appending to chat
-      this.said = text;
-
-      // Append to chat
-      this.appendChat(type, username);
-    },
-    /**
-     * Displays the chat box
-     *
-     * @param {object} chat A chat message
-     */
-    showChatMessage(chat) {
-      let message = '';
-
-      switch (chat.type) {
-      // Standard game
-      default:
-      case 'normal':
-        message = chat.text;
-        break;
-
-        // Player chat message
-      case 'chat':
-        message = `${chat.username}: <span style='color:${chat.color}'>${chat.text}</span>`;
-        break;
+      const normalised = normaliseIncoming(incoming);
+      if (!normalised) {
+        return;
       }
+      const {
+        text = '',
+        type = 'normal',
+        username = null,
+        color = '#1D56F2',
+      } = normalised;
 
-      return message;
+      this.said = text;
+      this.appendChat({ type, username, color, text });
     },
-    /**
-     * Send text message to server to send to other players in-game
-     */
-    sendMessage() {
-      Socket.emit('player:say', { said: this.said, id: this.game.player.socket_id });
-    },
-    /**
-     * Add message to chatbox
-     *
-     * @param {string} type The type of message we are adding
-     * @param {string} username The user sending the message
-     */
-    appendChat(type = 'chat', username = null) {
+    appendChat({ type, username, color, text }) {
+      if (!text) {
+        return;
+      }
+      const timestamp = Date.now();
+      const display = this.formatMessage(type, username, color, text);
       const message = {
         type,
-        color: '#1D56F2',
-        text: this.said,
         username,
+        color,
+        text,
+        display,
+        timestamp,
+        displayTime: formatTime(timestamp),
       };
 
-      this.chatbox = [
-        ...this.chatbox,
-        message,
-      ];
-
+      this.messages = [...this.messages.slice(-199), message];
       this.$emit('message-appended', { ...message });
-
-      // Clear user input
-      this.clearInput();
-
-      // Scroll chatbox to bottom
-      this.scrollToBottom();
+      this.$nextTick(() => this.scrollToBottom());
     },
-    /**
-     * Scroll chatbox to bottom on next Vue's life-cycle tick
-     */
+    formatMessage(type, username, color, text) {
+      switch (type) {
+      case 'chat':
+        return `<span class="chatbox__text--chat" style="color:${color}">${text}</span>`;
+      default:
+        return text;
+      }
+    },
+    sendMessage() {
+      const payload = this.said && this.said.trim();
+      if (!payload) {
+        return;
+      }
+      const player = this.game && this.game.player;
+      if (!player || !player.socket_id) {
+        return;
+      }
+      Socket.emit('player:say', { said: payload, id: player.socket_id });
+      this.clearInput();
+    },
+    clearInput() {
+      this.said = '';
+    },
     scrollToBottom() {
       this.$nextTick(() => {
-        // Scroll to bottom
-        const container = this.$el.querySelector('div#chat');
+        const container = this.$refs.messageList;
+        if (!container) {
+          return;
+        }
         container.scrollTop = container.scrollHeight;
       });
     },
-    /**
-     * Clear user input
-     */
-    clearInput() {
-      // Clear out user input
-      this.said = '';
+    focusInput() {
+      if (this.$refs.input) {
+        this.$refs.input.focus();
+      }
     },
-    chatboxClicked() {
-      bus.$emit('contextmenu:close');
+    handleFocus() {
+      this.hasFocus = true;
+      this.$emit('hover-state', true);
+      this.stopCountdown();
+    },
+    handleBlur() {
+      this.hasFocus = false;
+      this.$emit('hover-state', false);
+      if (!this.collapsed && !this.pinned && this.autoHideSeconds > 0) {
+        this.startCountdown();
+      }
+    },
+    startCountdown() {
+      if (this.autoHideSeconds <= 0) {
+        this.stopCountdown();
+        return;
+      }
+      this.stopCountdown();
+      this.countdownRemaining = this.autoHideSeconds;
+      this.countdownTimer = setInterval(() => {
+        if (this.countdownRemaining <= 1) {
+          this.stopCountdown();
+          this.$emit('countdown-complete');
+          return;
+        }
+        this.countdownRemaining -= 1;
+      }, 1000);
+    },
+    stopCountdown() {
+      if (this.countdownTimer) {
+        clearInterval(this.countdownTimer);
+        this.countdownTimer = null;
+      }
+      this.countdownRemaining = 0;
     },
   },
 };
 </script>
 
 <style lang="scss" scoped>
-@use 'sass:color';
-
-$background_color: #ededed;
-$default_color: #383838;
+@use '@/assets/scss/abstracts/tokens' as *;
+@use '@/assets/scss/abstracts/breakpoints' as *;
+@use '@/assets/scss/abstracts/mixins' as *;
 
 .chatbox {
+  position: relative;
   display: flex;
   flex-direction: column;
+  width: var(--chat-width);
+  max-width: 100%;
+  @include glass-panel(rgba(16, 20, 32, 0.78));
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+  transition: transform 180ms ease-out, opacity 180ms ease-out;
 
-  div#chat {
-    overflow-y: auto;
-    font-family: "ChatFont", sans-serif;
-    background-color: $background_color;
-    color: $default_color;
-    padding: 5px;
-    width: 100%;
-    text-align: left;
-    box-sizing: border-box;
-    resize: none;
-    border-width: 0;
-    outline: none;
-    font-size: 13px;
-    height: 110px;
-
-    &::-webkit-scrollbar-track {
-      background-color: transparent;
-    }
-
-    &::-webkit-scrollbar {
-      width: 8px;
-    }
-
-    &::-webkit-scrollbar-thumb {
-      background-color: color.adjust($background_color, $lightness: -55%);
-    }
+  &--collapsed {
+    pointer-events: none;
+    opacity: 0.1;
   }
 
-  input.typing {
-    text-indent: 1px;
-    font-family: "ChatFont", sans-serif;
-    background-color: #ededed;
-    color: #383838;
-    padding: 5px;
-    margin-top: 5px;
+  &--pinned {
+    box-shadow: var(--shadow-strong);
+  }
+
+  &--mobile {
     width: 100%;
-    border: 0;
-    box-sizing: border-box;
-    outline: none;
-    font-size: 13px;
-    border-bottom-left-radius: 3px;
+  }
+}
+
+.chatbox__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--space-sm) var(--space-md);
+  background: rgba(255, 255, 255, 0.05);
+  border-bottom: 1px solid var(--color-border-subtle);
+}
+
+.chatbox__meta {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.chatbox__title {
+  margin: 0;
+  font-size: var(--font-size-sm);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.chatbox__countdown {
+  margin: 0;
+  font-size: 0.75em;
+  color: var(--color-text-secondary);
+}
+
+.chatbox__actions {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-sm);
+}
+
+.chatbox__badge {
+  min-width: 22px;
+  padding: 2px 6px;
+  border-radius: 999px;
+  background: var(--color-accent);
+  color: #020307;
+  font-size: 0.75em;
+  text-align: center;
+}
+
+.chatbox__pin {
+  appearance: none;
+  border: 1px solid var(--color-border-subtle);
+  background: rgba(0, 0, 0, 0.35);
+  color: var(--color-text-primary);
+  border-radius: var(--radius-sm);
+  padding: 4px 10px;
+  font-size: var(--font-size-sm);
+  cursor: pointer;
+
+  &:hover {
+    border-color: var(--color-border-strong);
+    background: rgba(0, 0, 0, 0.55);
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--color-accent-strong);
+    outline-offset: 2px;
+  }
+}
+
+.chatbox__messages {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+  padding: var(--space-md);
+  overflow-y: auto;
+  max-height: 320px;
+  scroll-behavior: smooth;
+}
+
+.chatbox__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.chatbox__message {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  gap: var(--space-xs);
+  font-size: var(--font-size-sm);
+  color: var(--color-text-secondary);
+}
+
+.chatbox__username {
+  color: var(--color-accent-strong);
+  font-weight: 600;
+}
+
+.chatbox__text {
+  word-break: break-word;
+}
+
+.chatbox__text--chat {
+  font-weight: 500;
+}
+
+.chatbox__time {
+  font-size: 0.7em;
+  opacity: 0.6;
+}
+
+.chatbox__form {
+  display: flex;
+  align-items: stretch;
+  gap: var(--space-sm);
+  padding: var(--space-sm) var(--space-md) var(--space-md);
+}
+
+.chatbox__input {
+  flex: 1;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--color-border-subtle);
+  background: rgba(0, 0, 0, 0.45);
+  color: var(--color-text-primary);
+  padding: 8px;
+  font-size: var(--font-size-sm);
+
+  &:focus-visible {
+    outline: 2px solid var(--color-accent);
+    outline-offset: 2px;
+  }
+}
+
+.chatbox__submit {
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--color-border-subtle);
+  background: var(--color-accent);
+  color: #020307;
+  padding: 8px 12px;
+  font-size: var(--font-size-sm);
+  cursor: pointer;
+  font-weight: 600;
+
+  &:hover {
+    filter: brightness(1.1);
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--color-accent-strong);
+    outline-offset: 2px;
+  }
+}
+
+@include media('<=tablet') {
+  .chatbox {
+    width: min(420px, 96vw);
+  }
+
+  .chatbox__messages {
+    max-height: 260px;
+  }
+}
+
+@include media('<=mobile') {
+  .chatbox {
+    position: fixed;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    margin: auto;
+    width: 100%;
+    border-radius: var(--radius-lg) var(--radius-lg) 0 0;
+    box-shadow: 0 -16px 32px rgba(0, 0, 0, 0.55);
+    transform: translateY(0);
+  }
+
+  .chatbox--collapsed {
+    transform: translateY(calc(100% - 60px));
+    opacity: 1;
+    pointer-events: auto;
+  }
+
+  .chatbox__messages {
+    max-height: 45vh;
   }
 }
 </style>

--- a/src/components/hud/Quickbar.vue
+++ b/src/components/hud/Quickbar.vue
@@ -1,18 +1,31 @@
 <template>
   <nav class="quickbar" aria-label="Quick actions">
-    <button
+    <div
       v-for="(slot, index) in slots"
       :key="slot.id || index"
       :class="['quickbar__slot', { 'quickbar__slot--active': index === activeIndex }]"
-      type="button"
-      :title="slot.label"
-      @click="$emit('slot-activate', slot, index)"
     >
-      <span class="quickbar__icon">
-        <span v-if="slot.icon" aria-hidden="true">{{ slot.icon }}</span>
-      </span>
-      <span class="quickbar__key">{{ slot.hotkey }}</span>
-    </button>
+      <button
+        class="quickbar__activate"
+        type="button"
+        :title="slot.label"
+        @click="$emit('slot-activate', slot, index)"
+      >
+        <span class="quickbar__icon" aria-hidden="true">
+          <span v-if="slot.icon">{{ slot.icon }}</span>
+        </span>
+        <span class="quickbar__label">{{ slot.label || `Slot ${index + 1}` }}</span>
+      </button>
+      <button
+        class="quickbar__remap"
+        type="button"
+        :aria-label="`Remap ${slot.label || `slot ${index + 1}`}`"
+        @click="$emit('request-remap', slot, index)"
+      >
+        <span class="quickbar__hotkey">{{ slot.hotkey }}</span>
+        <span class="quickbar__remap-text">Remap</span>
+      </button>
+    </div>
   </nav>
 </template>
 
@@ -29,67 +42,130 @@ export default {
       default: -1,
     },
   },
+  emits: ['slot-activate', 'request-remap'],
 };
 </script>
 
 <style lang="scss" scoped>
+@use '@/assets/scss/abstracts/tokens' as *;
+@use '@/assets/scss/abstracts/mixins' as *;
+
 .quickbar {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(48px, 1fr));
-  gap: clamp(4px, 1vw, 8px);
-  width: clamp(320px, 50vw, 520px);
-  padding: clamp(4px, 0.8vw, 8px);
-  border-radius: 0;
-  background: rgba(20, 20, 24, 0.9);
-  box-shadow: 0 6px 16px rgba(0, 0, 0, 0.55);
-  backdrop-filter: none;
+  display: flex;
+  align-items: stretch;
+  justify-content: center;
+  gap: var(--space-sm);
+  padding: var(--space-sm) var(--space-md);
+  border-radius: var(--radius-lg);
+  background: rgba(12, 16, 28, 0.82);
+  border: 1px solid var(--color-border-subtle);
+  box-shadow: var(--shadow-soft);
+  min-width: clamp(320px, 40vw, 640px);
 }
 
 .quickbar__slot {
-  position: relative;
-  display: inline-flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  padding: clamp(4px, 1vw, 6px);
-  border-radius: 0;
-  background: linear-gradient(180deg, rgba(56, 56, 56, 0.9), rgba(26, 26, 26, 0.95));
+  display: grid;
+  grid-template-columns: auto;
+  grid-template-rows: auto auto;
+  align-items: stretch;
+  justify-items: stretch;
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  background: linear-gradient(180deg, rgba(36, 42, 64, 0.95), rgba(18, 22, 34, 0.95));
   border: 1px solid rgba(255, 255, 255, 0.08);
-  color: #f4f4f4;
-  font-family: "GameFont", sans-serif;
-  cursor: pointer;
-  transition: box-shadow 120ms ease-out, border-color 120ms ease-out;
+  transition: transform 140ms ease-out, box-shadow 140ms ease-out, border-color 140ms ease-out;
 
   &:hover {
-    border-color: rgba(255, 255, 255, 0.25);
-    box-shadow: 0 0 0 1px rgba(255, 255, 255, 0.25);
-  }
-
-  &:focus-visible {
-    outline: 2px solid rgba(255, 255, 255, 0.85);
-    outline-offset: 2px;
+    transform: translateY(-2px);
+    box-shadow: 0 10px 18px rgba(0, 0, 0, 0.45);
   }
 }
 
 .quickbar__slot--active {
-  box-shadow: 0 0 0 2px rgba(255, 214, 102, 0.6);
   border-color: rgba(255, 214, 102, 0.8);
+  box-shadow: 0 0 0 2px rgba(255, 214, 102, 0.45), 0 12px 24px rgba(0, 0, 0, 0.55);
+}
+
+.quickbar__activate {
+  appearance: none;
+  background: transparent;
+  border: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+  padding: var(--space-sm);
+  color: var(--color-text-primary);
+  font-family: 'GameFont', sans-serif;
+  cursor: pointer;
+
+  &:focus-visible {
+    outline: 2px solid var(--color-accent);
+    outline-offset: -2px;
+  }
 }
 
 .quickbar__icon {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: clamp(26px, 3vw, 32px);
-  height: clamp(26px, 3vw, 32px);
-  margin-bottom: 0.25em;
-  border-radius: 0;
-  background: rgba(0, 0, 0, 0.45);
-  font-size: clamp(12px, 2vw, 16px);
+  width: clamp(28px, 3vw, 36px);
+  height: clamp(28px, 3vw, 36px);
+  border-radius: 50%;
+  background: rgba(0, 0, 0, 0.35);
+  font-size: clamp(12px, 2vw, 18px);
 }
 
-.quickbar__key {
-  font-size: clamp(12px, 1.5vw, 14px);
-  letter-spacing: 0.05em;
+.quickbar__label {
+  font-size: var(--font-size-sm);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.quickbar__remap {
+  appearance: none;
+  border: 0;
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(12, 16, 28, 0.72);
+  color: var(--color-text-secondary);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-sm);
+  padding: 6px var(--space-sm);
+  font-size: var(--font-size-sm);
+  cursor: pointer;
+
+  &:hover {
+    color: var(--color-accent-strong);
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--color-accent);
+    outline-offset: -2px;
+  }
+}
+
+.quickbar__hotkey {
+  font-family: 'GameFont', sans-serif;
+  font-size: var(--font-size-sm);
+  letter-spacing: 0.08em;
+}
+
+.quickbar__remap-text {
+  font-size: 0.75em;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+@media (max-width: 768px) {
+  .quickbar {
+    min-width: min(90vw, 520px);
+    padding: var(--space-xs) var(--space-sm);
+  }
+
+  .quickbar__label {
+    font-size: 0.7rem;
+  }
 }
 </style>

--- a/src/components/ui/panes/PaneCard.vue
+++ b/src/components/ui/panes/PaneCard.vue
@@ -1,0 +1,138 @@
+<template>
+  <section
+    class="pane-card"
+    :class="{ 'pane-card--compressed': compressed }"
+    :aria-label="ariaLabel"
+  >
+    <header class="pane-card__header">
+      <h2 class="pane-card__title">{{ title }}</h2>
+      <div class="pane-card__actions">
+        <slot name="actions" />
+        <button
+          v-if="dismissible"
+          class="pane-card__dismiss"
+          type="button"
+          @click="$emit('dismiss')"
+        >
+          <span class="sr-only">Close</span>
+          ×
+        </button>
+      </div>
+    </header>
+    <div class="pane-card__body">
+      <slot />
+    </div>
+  </section>
+</template>
+
+<script>
+export default {
+  name: 'PaneCard',
+  props: {
+    title: {
+      type: String,
+      default: '',
+    },
+    compressed: {
+      type: Boolean,
+      default: false,
+    },
+    dismissible: {
+      type: Boolean,
+      default: false,
+    },
+    ariaLabel: {
+      type: String,
+      default: '',
+    },
+  },
+  emits: ['dismiss'],
+};
+</script>
+
+<style lang="scss" scoped>
+@use '@/assets/scss/abstracts/tokens' as *;
+
+.pane-card {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  border-radius: var(--radius-lg);
+  background: linear-gradient(145deg, rgba(18, 21, 32, 0.92), rgba(12, 14, 22, 0.88));
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: 0 22px 40px rgba(0, 0, 0, 0.45);
+  color: #f8f8f8;
+  overflow: hidden;
+}
+
+.pane-card--compressed {
+  border-radius: var(--radius-md);
+}
+
+.pane-card__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--space-md) var(--space-lg);
+  gap: var(--space-md);
+  background: rgba(255, 255, 255, 0.03);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.pane-card__title {
+  font-family: 'GameFont', sans-serif;
+  font-size: clamp(14px, 1.4vw, 18px);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  margin: 0;
+}
+
+.pane-card__actions {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-sm);
+}
+
+.pane-card__dismiss {
+  appearance: none;
+  border: 1px solid rgba(255, 255, 255, 0.25);
+  background: rgba(0, 0, 0, 0.35);
+  color: inherit;
+  border-radius: var(--radius-sm);
+  width: 28px;
+  height: 28px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: border-color 160ms ease-out, background 160ms ease-out;
+
+  &:hover {
+    border-color: rgba(255, 255, 255, 0.45);
+    background: rgba(0, 0, 0, 0.55);
+  }
+
+  &:focus-visible {
+    outline: 2px solid rgba(255, 255, 255, 0.85);
+    outline-offset: 2px;
+  }
+}
+
+.pane-card__body {
+  padding: var(--space-lg);
+  overflow: auto;
+  max-height: min(72vh, 640px);
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+</style>

--- a/src/components/ui/panes/PaneHost.vue
+++ b/src/components/ui/panes/PaneHost.vue
@@ -1,0 +1,301 @@
+<template>
+  <div
+    class="pane-host"
+    :class="[`pane-host--${layoutMode}`]"
+  >
+    <transition
+      name="pane-slide"
+      appear
+    >
+      <aside
+        v-if="showLeftPane"
+        key="left"
+        class="pane-host__side pane-host__side--left"
+      >
+        <PaneCard
+          :title="leftPaneTitle"
+          :aria-label="`${leftPaneTitle} panel`"
+          :compressed="layoutMode !== 'desktop'"
+        >
+          <component
+            :is="leftPaneComponent"
+            v-if="leftPaneComponent"
+            :game="game"
+          />
+        </PaneCard>
+      </aside>
+    </transition>
+
+    <div class="pane-host__center">
+      <slot />
+    </div>
+
+    <transition
+      name="pane-slide"
+      appear
+    >
+      <aside
+        v-if="showRightPane"
+        key="right"
+        class="pane-host__side pane-host__side--right"
+      >
+        <PaneCard
+          :title="rightPaneTitle"
+          :aria-label="`${rightPaneTitle} panel`"
+          :compressed="layoutMode !== 'desktop'"
+        >
+          <component
+            :is="rightPaneComponent"
+            v-if="rightPaneComponent"
+            :game="game"
+          />
+        </PaneCard>
+      </aside>
+    </transition>
+
+    <transition name="pane-overlay">
+      <div
+        v-if="showOverlay"
+        class="pane-host__overlay"
+        role="dialog"
+        aria-modal="true"
+        @click.self="$emit('overlay-close')"
+      >
+        <PaneCard
+          ref="overlayCard"
+          class="pane-host__overlay-card"
+          :title="overlayTitle"
+          :dismissible="true"
+          :aria-label="`${overlayTitle} overlay`"
+          @dismiss="$emit('overlay-close')"
+        >
+          <component
+            :is="overlayComponent"
+            v-if="overlayComponent"
+            :game="game"
+            v-bind="overlayPane && overlayPane.props ? overlayPane.props : {}"
+          />
+        </PaneCard>
+      </div>
+    </transition>
+  </div>
+</template>
+
+<script>
+import PaneCard from './PaneCard.vue';
+
+export default {
+  name: 'PaneHost',
+  components: {
+    PaneCard,
+  },
+  props: {
+    layoutMode: {
+      type: String,
+      default: 'desktop',
+    },
+    game: {
+      type: Object,
+      required: true,
+    },
+    registry: {
+      type: Object,
+      default: () => ({}),
+    },
+    leftPane: {
+      type: String,
+      default: null,
+    },
+    rightPane: {
+      type: String,
+      default: null,
+    },
+    overlayPane: {
+      type: Object,
+      default: () => ({ id: null, title: '', props: {} }),
+    },
+  },
+  emits: ['overlay-close'],
+  computed: {
+    paneRegistry() {
+      return this.registry || {};
+    },
+    leftPaneEntry() {
+      if (!this.leftPane) {
+        return null;
+      }
+      return this.paneRegistry[this.leftPane] || null;
+    },
+    rightPaneEntry() {
+      if (!this.rightPane) {
+        return null;
+      }
+      return this.paneRegistry[this.rightPane] || null;
+    },
+    overlayPaneEntry() {
+      if (!this.overlayPane || !this.overlayPane.id) {
+        return null;
+      }
+      return this.paneRegistry[this.overlayPane.id] || null;
+    },
+    leftPaneComponent() {
+      return this.leftPaneEntry && this.leftPaneEntry.component;
+    },
+    rightPaneComponent() {
+      return this.rightPaneEntry && this.rightPaneEntry.component;
+    },
+    overlayComponent() {
+      return this.overlayPaneEntry && this.overlayPaneEntry.component;
+    },
+    leftPaneTitle() {
+      if (!this.leftPaneEntry) {
+        return '';
+      }
+      return this.leftPaneEntry.title || this.capitalise(this.leftPane);
+    },
+    rightPaneTitle() {
+      if (!this.rightPaneEntry) {
+        return '';
+      }
+      return this.rightPaneEntry.title || this.capitalise(this.rightPane);
+    },
+    overlayTitle() {
+      if (!this.overlayPaneEntry) {
+        return '';
+      }
+      if (this.overlayPane && this.overlayPane.title) {
+        return this.overlayPane.title;
+      }
+      return this.overlayPaneEntry.title || this.capitalise(this.overlayPane.id);
+    },
+    showLeftPane() {
+      if (!this.leftPaneComponent) {
+        return false;
+      }
+      return this.layoutMode === 'desktop';
+    },
+    showRightPane() {
+      if (!this.rightPaneComponent) {
+        return false;
+      }
+      return this.layoutMode === 'desktop';
+    },
+    showOverlay() {
+      if (!this.overlayComponent) {
+        return false;
+      }
+      if (this.layoutMode === 'desktop' && this.overlayPane && (this.overlayPane.id === this.leftPane || this.overlayPane.id === this.rightPane)) {
+        return false;
+      }
+      return true;
+    },
+  },
+  methods: {
+    capitalise(value) {
+      if (typeof value !== 'string') {
+        return '';
+      }
+      return value.charAt(0).toUpperCase() + value.slice(1);
+    },
+  },
+};
+</script>
+
+<style lang="scss" scoped>
+@use '@/assets/scss/abstracts/tokens' as *;
+@use '@/assets/scss/abstracts/breakpoints' as *;
+
+.pane-host {
+  position: relative;
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  gap: var(--space-lg);
+  width: 100%;
+  height: 100%;
+  align-items: stretch;
+  transition: grid-template-columns 160ms ease-out, gap 160ms ease-out;
+
+  &--tablet,
+  &--mobile {
+    grid-template-columns: minmax(0, 1fr);
+  }
+}
+
+.pane-host__side {
+  display: flex;
+  flex-direction: column;
+  min-width: clamp(240px, 18vw, 320px);
+  pointer-events: auto;
+
+  &--left {
+    align-items: stretch;
+  }
+
+  &--right {
+    align-items: stretch;
+  }
+}
+
+.pane-host__center {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-xl);
+  width: 100%;
+}
+
+.pane-host__overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(10, 12, 18, 0.65);
+  backdrop-filter: blur(12px);
+  display: grid;
+  align-items: center;
+  justify-items: center;
+  padding: var(--space-2xl) var(--space-lg);
+  z-index: 40;
+}
+
+.pane-host__overlay-card {
+  max-width: min(720px, 94vw);
+  width: 100%;
+}
+
+@include media('<=tablet') {
+  .pane-host__side {
+    min-width: min(420px, 90vw);
+  }
+}
+
+@include media('<=mobile') {
+  .pane-host__overlay {
+    padding: var(--space-lg) var(--space-md);
+  }
+
+  .pane-host__side {
+    min-width: 100%;
+  }
+}
+
+.pane-slide-enter-active,
+.pane-slide-leave-active {
+  transition: opacity 180ms ease-out, transform 180ms ease-out;
+}
+
+.pane-slide-enter-from,
+.pane-slide-leave-to {
+  opacity: 0;
+  transform: translateY(12px);
+}
+
+.pane-overlay-enter-active,
+.pane-overlay-leave-active {
+  transition: opacity 200ms ease-out;
+}
+
+.pane-overlay-enter-from,
+.pane-overlay-leave-to {
+  opacity: 0;
+}
+</style>


### PR DESCRIPTION
## Summary
- add a PaneHost/PaneCard system to orchestrate responsive side panes and overlays across breakpoints
- rebuild the chatbox into a semi-transparent overlay with mobile bottom-sheet behavior and badge/timer controls
- refresh the quickbar and SCSS token architecture to anchor the HUD between orbs and introduce reusable theme variables

## Testing
- `npm run lint` *(fails: vue-cli-service not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68fd6e2ac3ac83218ae8cf4fe9c8e185