### PR TITLE
Refactor socket broadcast cleanup

### DIFF
--- a/tests/unit/socket-broadcast.spec.js
+++ b/tests/unit/socket-broadcast.spec.js
@@ -1,0 +1,78 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import Socket from '#server/socket.js';
+import world from '#server/core/world.js';
+
+const createClient = ({ id, readyState }) => ({
+  id,
+  readyState,
+  send: vi.fn(),
+});
+
+describe('Socket.broadcast', () => {
+  const originalClients = world.clients;
+  const originalPlayers = [...world.players];
+
+  beforeEach(() => {
+    world.clients = [];
+    world._players = [];
+  });
+
+  afterEach(() => {
+    world.clients = originalClients;
+    world._players = [...originalPlayers];
+  });
+
+  it('sends a single payload to connected clients and removes closed ones', () => {
+    const openClient = createClient({ id: 'open', readyState: 1 });
+    const closedClient = createClient({ id: 'closed', readyState: 3 });
+
+    world.clients = [openClient, closedClient];
+    world._players = [
+      { socket_id: 'open' },
+      { socket_id: 'closed' },
+    ];
+
+    const players = [
+      { socket_id: 'open' },
+      { socket_id: 'closed' },
+    ];
+
+    Socket.broadcast('game:update', { foo: 'bar' }, players);
+
+    expect(openClient.send).toHaveBeenCalledTimes(1);
+    const [payloadString] = openClient.send.mock.calls[0];
+    const payload = JSON.parse(payloadString);
+
+    expect(payload.event).toBe('game:update');
+    expect(payload.data).toEqual({ foo: 'bar' });
+    expect(typeof payload.meta.sentAt).toBe('number');
+
+    expect(closedClient.send).not.toHaveBeenCalled();
+    expect(world.clients).toEqual([openClient]);
+  });
+
+  it('ignores clients outside of the provided player list while pruning closed sockets', () => {
+    const targetedClient = createClient({ id: 'target', readyState: 1 });
+    const ignoredClient = createClient({ id: 'ignored', readyState: 1 });
+    const closedClient = createClient({ id: 'closed', readyState: 3 });
+
+    world.clients = [targetedClient, ignoredClient, closedClient];
+    world._players = [
+      { socket_id: 'target' },
+      { socket_id: 'ignored' },
+      { socket_id: 'closed' },
+    ];
+
+    const players = [
+      { socket_id: 'target' },
+    ];
+
+    Socket.broadcast('game:event', { value: 42 }, players);
+
+    expect(targetedClient.send).toHaveBeenCalledTimes(1);
+    expect(ignoredClient.send).not.toHaveBeenCalled();
+    expect(closedClient.send).not.toHaveBeenCalled();
+
+    expect(world.clients).toEqual([targetedClient, ignoredClient]);
+  });
+});


### PR DESCRIPTION
## Summary
- avoid mutating `world.clients` during broadcast and prune closed sockets after sends
- pre-serialize the payload and only emit to eligible clients
- add unit tests covering broadcast cleanup and player filtering

## Testing
- npm run test:unit *(fails: missing `jsdom` dependency in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_6900e0b86fd48321a6b8bb464974983b