### PR TITLE
Refactor world scene mutations into helper methods

### DIFF
--- a/server/core/item.js
+++ b/server/core/item.js
@@ -35,7 +35,7 @@ class Item {
         Socket.broadcast('world:foreground:update', world.map.foreground);
 
         // Take resource off respawn check
-        world.respawns.resources.splice(index, 1);
+        world.removeResourceRespawn(index);
       }
     });
   }
@@ -57,7 +57,7 @@ class Item {
           );
 
           respawned.respawnIn = item.respawnIn;
-          world.items.push(respawned);
+          world.addItem(respawned);
 
           Socket.broadcast('world:itemDropped', world.items);
 

--- a/server/core/npc.js
+++ b/server/core/npc.js
@@ -142,7 +142,7 @@ class NPC {
    */
   static load(context) {
     npcs.forEach((npc) => {
-      world.npcs.push(new NPC(npc));
+      world.addNpc(new NPC(npc));
     }, context);
 
     console.log(`${emoji.get('walking')}  Loading NPCs...`);

--- a/server/core/skills/index.js
+++ b/server/core/skills/index.js
@@ -60,7 +60,7 @@ export default class Skill {
         { timestamp: Date.now() },
       );
 
-      world.items.push(dropped);
+      world.addItem(dropped);
 
       Socket.broadcast('world:itemDropped', world.items);
     } else {

--- a/tests/unit/world-manager.spec.js
+++ b/tests/unit/world-manager.spec.js
@@ -1,0 +1,65 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import world from '#server/core/world.js';
+
+const resetWorldCollections = () => {
+  const town = world.getDefaultTown();
+  town.npcs = [];
+  town.items = [];
+  town.respawns = {
+    items: [],
+    monsters: [],
+    resources: [],
+  };
+};
+
+describe('WorldManager collection helpers', () => {
+  beforeEach(() => {
+    resetWorldCollections();
+  });
+
+  it('adds NPCs to the default scene', () => {
+    const npc = { uuid: 'npc-1', id: 'npc:1' };
+
+    const inserted = world.addNpc(npc);
+
+    expect(inserted).toBe(npc);
+    expect(world.npcs).toContain(npc);
+  });
+
+  it('removes NPCs by identifier', () => {
+    const npcA = { uuid: 'npc-a', id: 'npc:a' };
+    const npcB = { uuid: 'npc-b', id: 'npc:b' };
+    world.addNpc(npcA);
+    world.addNpc(npcB);
+
+    const removed = world.removeNpc({ uuid: 'npc-a' });
+
+    expect(removed).toEqual(npcA);
+    expect(world.npcs).toEqual([npcB]);
+  });
+
+  it('adds and removes items using predicates', () => {
+    const itemA = { uuid: 'item-a', id: 'item:a' };
+    const itemB = { uuid: 'item-b', id: 'item:b' };
+    world.addItem(itemA);
+    world.addItem(itemB);
+
+    const removed = world.removeItem(entry => entry.id === 'item:b');
+
+    expect(removed).toEqual(itemB);
+    expect(world.items).toEqual([itemA]);
+  });
+
+  it('removes resource respawns by index', () => {
+    const town = world.getDefaultTown();
+    const resourceA = { uuid: 'res-a' };
+    const resourceB = { uuid: 'res-b' };
+    town.respawns.resources = [resourceA, resourceB];
+
+    const removed = world.removeResourceRespawn(0);
+
+    expect(removed).toEqual(resourceA);
+    expect(town.respawns.resources).toEqual([resourceB]);
+  });
+});


### PR DESCRIPTION
## Summary
- add helper utilities to the world manager to encapsulate NPC, item, and respawn mutations
- update NPC loading, item drops, and respawn logic to rely on the new helpers
- add unit coverage for the collection helpers to prevent regression

## Testing
- npm run test:unit *(fails: missing jsdom dependency in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_6900e1c6790083218d4bc4886cd489c5