### PR TITLE
Unify ESLint configuration for unit tests

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -53,4 +53,12 @@ export default [
       'vue/multi-word-component-names': 'off',
     },
   },
+  {
+    files: ['tests/unit/**/*.{js,vue}'],
+    languageOptions: {
+      globals: {
+        ...globals.jest,
+      },
+    },
+  },
 ];

--- a/tests/unit/.eslintrc.js
+++ b/tests/unit/.eslintrc.js
@@ -1,5 +1,0 @@
-module.exports = {
-  env: {
-    jest: true,
-  },
-};


### PR DESCRIPTION
## Summary
- remove the dedicated ESLint config from tests/unit
- add a flat-config override so unit tests retain their Jest globals

## Testing
- npm run lint *(fails: existing unresolved import and resolver errors)*

------
https://chatgpt.com/codex/tasks/task_e_6900fcec6a048321b51ecdc1eb83d7e6