### PR TITLE
Convert server runtime to ESM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ scratchpad.txt
 
 #History Files
 *.history
+
+# Generated runtime data
+server/data/

--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -1,4 +1,4 @@
-module.exports = {
+const config = {
   apps: [{
     name: 'server',
     script: './server/index.js',
@@ -12,3 +12,5 @@ module.exports = {
     },
   }],
 };
+
+export default config;

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,5 +1,7 @@
-module.exports = {
+const config = {
   plugins: {
     autoprefixer: {},
   },
 };
+
+export default config;

--- a/server/config.js
+++ b/server/config.js
@@ -58,4 +58,7 @@ const config = {
   },
 };
 
+const { map, player } = config;
+
+export { map, player };
 export default config;

--- a/server/core/map.js
+++ b/server/core/map.js
@@ -3,7 +3,7 @@ import { armor, jewelry, weapons } from '#server/core/data/respawn/index.js';
 import MapUtils from '#shared/map-utils.js';
 import PF from 'pathfinding';
 import config from '#server/config.js';
-import surfaceMap from '#server/maps/layers/surface.json' assert { type: 'json' };
+import surfaceMap from '#server/maps/layers/surface.json' with { type: 'json' };
 import ItemFactory from './items/factory.js';
 import { Shop } from './functions/index.js';
 import world from './world.js';

--- a/server/index.js
+++ b/server/index.js
@@ -99,7 +99,7 @@ app.get('/world/players', (_req, res) => res.send(world.players));
 app.get('/world/respawns', (_req, res) => res.send(world.respawns));
 app.get('/world/shops', (_req, res) => res.send(world.shops));
 
-app.get('*', (_req, res) => {
+app.use((_req, res) => {
   if (hasClientBundle()) {
     res.sendFile(path.join(distDir, 'index.html'));
     return;

--- a/server/player/action.js
+++ b/server/player/action.js
@@ -1,7 +1,7 @@
 import UI from '#shared/ui.js';
 import World from '#server/core/world.js';
 import config from '#server/config.js';
-import { merge } from 'lodash';
+import merge from 'lodash/merge.js';
 import Handler from './handler.js';
 import playerEvent from './handlers/actions/index.js';
 

--- a/server/player/handlers/socket-events/index.js
+++ b/server/player/handlers/socket-events/index.js
@@ -6,7 +6,7 @@ import Authentication from '#server/player/authentication.js';
 import Player from '#server/core/player.js';
 import Socket from '#server/socket.js';
 import config from '#server/config.js';
-import playerGuest from '#server/core/data/helpers/player.json' assert { type: 'json' };
+import playerGuest from '#server/core/data/helpers/player.json' with { type: 'json' };
 import world from '#server/core/world.js';
 
 export default {

--- a/server/socket.js
+++ b/server/socket.js
@@ -1,4 +1,4 @@
-import WebSocket from 'ws';
+import { WebSocketServer } from 'ws';
 import world from '#server/core/world.js';
 
 /**
@@ -8,7 +8,7 @@ import world from '#server/core/world.js';
 
 class Socket {
   constructor(server) {
-    this.ws = new WebSocket.Server({ server });
+    this.ws = new WebSocketServer({ server });
     this.clients = world.clients;
   }
 


### PR DESCRIPTION
## Summary
- convert pm2 and PostCSS configs to ESM modules and ignore generated identity store data
- fix server imports for JSON payloads, lodash merge, and ws server construction under pure ESM
- adjust Express catch-all routing and expose named config exports used across the server

## Testing
- npm run dev:server

------
https://chatgpt.com/codex/tasks/task_e_6900fe29baa48321874136e5dcbedf8f