### PR TITLE
Update docs for unified dev server command

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -4,17 +4,17 @@ We love pull requests from everyone. By participating in this project, you agree
 
 Fork the repo.
 
-Install the dependencies:
+Make sure you are on the toolchain published in `.nvmrc` / `.tool-versions` (Node.js 22 + npm 10). The project relies on the Vite bundler and Pinia-powered stores baked into the existing npm scripts—no global installs required.
+
+Install the dependencies (the Vite client and Express/WebSocket server live in the same workspace, so one install covers both):
 
     npm install
 
-Start the development server:
+Start the development environment (Vite + backend run together via `npm run dev`):
 
-    npm run serve
+    npm run dev
 
-In another terminal, start the server:
-
-    npm run dev:node
+Need to focus on a single process? Use `npm run dev:client` for the Vite UI or `npm run dev:server` for the Express/WebSocket runtime.
 
 Make changes.
 

--- a/docs/development-setup.md
+++ b/docs/development-setup.md
@@ -11,6 +11,7 @@ Delaford historically targeted the archived 2020-era runtime stack, but the proj
   - **Volta**: `volta install` inside the project folder
   - **asdf**: `asdf install`
 - Git, and a working C compiler toolchain if you are on Windows (needed for native node-gyp modules).
+- You do **not** need any global Vue CLI installs. The repo uses [Vite](https://vitejs.dev/) for dev/build tooling and [Pinia](https://pinia.vuejs.org/) for client-side state, both already defined as local dependencies and exposed through npm scripts.
 
 ## First-time setup
 
@@ -39,7 +40,7 @@ Delaford historically targeted the archived 2020-era runtime stack, but the proj
   npm run dev
   ```
   This runs the Vite dev server and the Express/WebSocket backend in parallel via `concurrently`. Both processes hot-reload on file changes.
-- Visit `http://localhost:5173` to interact with the game client. The Express + WebSocket server listens on `http://localhost:6500`.
+- Visit `http://localhost:5173` to interact with the game client. The Express API wrapper responds on `http://localhost:6500`, and the WebSocket server listens on `ws://localhost:9000`.
 - Want to debug the backend only? Use `npm run dev:server`. For client-only work use `npm run dev:client`.
 
 ## Optional environment variables


### PR DESCRIPTION
## Summary
- replace legacy `npm run serve` / `npm run dev:node` references with the current `npm run dev`
- document the Node 22 toolchain along with bundled Vite and Pinia dependencies in the contributor docs
- clarify local development ports for the Express API and WebSocket endpoints

## Testing
- not run (documentation-only change)

------
https://chatgpt.com/codex/tasks/task_e_6901019325cc8321b1aaffa5799f51b6