### PR TITLE
Refactor context menu actions into strategies

### DIFF
--- a/server/core/context-menu/strategies/bank-action.js
+++ b/server/core/context-menu/strategies/bank-action.js
@@ -1,0 +1,30 @@
+import UI from '#shared/ui.js';
+
+const quantities = [1, 5, 10, 'All'];
+
+const bankActionStrategy = {
+  actionIds: ['player:screen:bank:action'],
+  description: 'Transfer items between bank and inventory in set quantities.',
+  canExecute: ({ menu, selectedItemData }) => (
+    (menu.clickedOn('bankSlot') || menu.clickedOn('inventorySlot'))
+      && Boolean(selectedItemData)
+  ),
+  execute: ({ action, menu, selectedItemData }) => {
+    if (!selectedItemData || !menu.canDoAction(selectedItemData.actions, action)) {
+      return [];
+    }
+
+    const color = UI.getContextSubjectColor(selectedItemData.context);
+
+    return quantities.map((quantity) => ({
+      label: `${action.name}-${quantity.toString()} <span style='color:${color}'>${selectedItemData.name}</span>`,
+      params: { quantity },
+      action,
+      examine: selectedItemData.examine,
+      type: 'item',
+      id: selectedItemData.id,
+    }));
+  },
+};
+
+export default bankActionStrategy;

--- a/server/core/context-menu/strategies/cancel.js
+++ b/server/core/context-menu/strategies/cancel.js
@@ -1,0 +1,8 @@
+const cancelStrategy = {
+  actionIds: ['Cancel'],
+  description: 'Close the context menu without performing an action.',
+  canExecute: () => false,
+  execute: () => [],
+};
+
+export default cancelStrategy;

--- a/server/core/context-menu/strategies/equip.js
+++ b/server/core/context-menu/strategies/equip.js
@@ -1,0 +1,32 @@
+import UI from '#shared/ui.js';
+
+const equipStrategy = {
+  actionIds: ['item:equip'],
+  description: 'Equip an item from the player inventory.',
+  canExecute: ({ menu, selectedItemData }) => (
+    menu.clickedOn('inventorySlot')
+      && menu.isFromInventory()
+      && Boolean(selectedItemData)
+  ),
+  execute: ({ action, menu, dynamicItem, miscData, selectedItemData }) => {
+    if (!selectedItemData || !menu.canDoAction(selectedItemData.actions, action)) {
+      return [];
+    }
+
+    const displayName = dynamicItem && dynamicItem.name ? dynamicItem.name : selectedItemData.name;
+    const referenceUuid = dynamicItem && dynamicItem.uuid ? dynamicItem.uuid : selectedItemData.uuid;
+    const referenceId = dynamicItem && dynamicItem.id ? dynamicItem.id : selectedItemData.id;
+    const color = UI.getContextSubjectColor(selectedItemData.context);
+
+    return [{
+      label: `${action.name} <span style='color:${color}'>${displayName}</span>`,
+      action,
+      type: 'item',
+      miscData,
+      uuid: referenceUuid,
+      id: referenceId,
+    }];
+  },
+};
+
+export default equipStrategy;

--- a/server/core/context-menu/strategies/examine.js
+++ b/server/core/context-menu/strategies/examine.js
@@ -1,0 +1,92 @@
+import UI from '#shared/ui.js';
+import Query from '#server/core/data/query.js';
+
+const examineStrategy = {
+  actionIds: ['player:examine', 'player:screen:npc:trade:action:value'],
+  description: 'Inspect items, NPCs, or foreground objects for more information.',
+  canExecute: ({ menu }) => menu.isFromGameCanvas() || menu.isFromInventory(),
+  execute: ({
+    action,
+    menu,
+    foregroundData,
+    npcs,
+    groundItems,
+    dynamicItem,
+    selectedItemData,
+  }) => {
+    const results = [];
+
+    if (menu.isFromGameCanvas()) {
+      if (foregroundData && menu.canDoAction(foregroundData.actions, action)) {
+        const fgColor = UI.getContextSubjectColor(foregroundData.context);
+        results.push({
+          label: `${action.name} <span style='color:${fgColor}'>${foregroundData.name}</span>`,
+          action,
+          examine: foregroundData.examine,
+          type: 'foreground',
+          id: foregroundData.id,
+        });
+      }
+
+      if (Array.isArray(npcs)) {
+        npcs.forEach((npc) => {
+          if (!menu.canDoAction(npc.actions, action)) {
+            return;
+          }
+          const color = UI.getContextSubjectColor(npc.context);
+          results.push({
+            label: `${action.name} <span style='color:${color}'>${npc.name}</span>`,
+            action,
+            examine: npc.examine,
+            type: 'npc',
+            id: npc.id,
+          });
+        });
+      }
+
+      if (Array.isArray(groundItems)) {
+        groundItems.forEach((item) => {
+          const combined = { ...(Query.getItemData(item.id) || {}), ...item };
+          const {
+            name, examine, id, actions, timestamp,
+          } = combined;
+
+          if (!menu.canDoAction(actions, action)) {
+            return;
+          }
+
+          const color = UI.getContextSubjectColor(item.context);
+          results.push({
+            label: `Examine <span style='color:${color}'>${name}</span>`,
+            action,
+            examine,
+            type: 'item',
+            id,
+            timestamp,
+          });
+        });
+      }
+    }
+
+    if (menu.isFromInventory() && selectedItemData) {
+      const color = UI.getContextSubjectColor(selectedItemData.context);
+      const displayName = dynamicItem && dynamicItem.name ? dynamicItem.name : selectedItemData.name;
+      const displayExamine = dynamicItem && dynamicItem.examine ? dynamicItem.examine : selectedItemData.examine;
+      const referenceId = dynamicItem && dynamicItem.id ? dynamicItem.id : selectedItemData.id;
+
+      if (menu.canDoAction(selectedItemData.actions, action)) {
+        results.push({
+          label: `${action.name} <span style='color:${color}'>${displayName}</span>`,
+          action,
+          examine: displayExamine,
+          type: 'item',
+          id: referenceId,
+        });
+      }
+    }
+
+    return results;
+  },
+};
+
+export default examineStrategy;

--- a/server/core/context-menu/strategies/inventory-drop.js
+++ b/server/core/context-menu/strategies/inventory-drop.js
@@ -1,0 +1,32 @@
+import UI from '#shared/ui.js';
+
+const inventoryDropStrategy = {
+  actionIds: ['player:inventory-drop'],
+  description: 'Drop an item from the player inventory onto the ground.',
+  canExecute: ({ menu, selectedItemData }) => (
+    menu.clickedOn('inventorySlot')
+      && menu.isFromInventory()
+      && Boolean(selectedItemData)
+  ),
+  execute: ({ action, menu, dynamicItem, miscData, selectedItemData }) => {
+    if (!selectedItemData || !menu.canDoAction(selectedItemData.actions, action)) {
+      return [];
+    }
+
+    const displayName = dynamicItem && dynamicItem.name ? dynamicItem.name : selectedItemData.name;
+    const referenceUuid = dynamicItem && dynamicItem.uuid ? dynamicItem.uuid : selectedItemData.uuid;
+    const referenceId = dynamicItem && dynamicItem.id ? dynamicItem.id : selectedItemData.id;
+    const color = UI.getContextSubjectColor(selectedItemData.context);
+
+    return [{
+      label: `${action.name} <span style='color:${color}'>${displayName}</span>`,
+      action,
+      type: 'item',
+      miscData,
+      uuid: referenceUuid,
+      id: referenceId,
+    }];
+  },
+};
+
+export default inventoryDropStrategy;

--- a/server/core/context-menu/strategies/mining-rock.js
+++ b/server/core/context-menu/strategies/mining-rock.js
@@ -1,0 +1,30 @@
+import UI from '#shared/ui.js';
+
+const miningRockStrategy = {
+  actionIds: ['player:resource:mining:rock'],
+  description: 'Mine a resource node located at the clicked tile.',
+  canExecute: ({ foregroundData, menu, action }) => (
+    Boolean(foregroundData)
+      && menu.canDoAction(foregroundData, action)
+  ),
+  execute: ({ action, foregroundData, coordinates }) => {
+    if (!foregroundData) {
+      return [];
+    }
+
+    const color = UI.getContextSubjectColor(foregroundData.context);
+    return [{
+      label: `${action.name} <span style='color:${color}'>${foregroundData.name}</span>`,
+      action,
+      type: 'mine',
+      coordinates: coordinates.map,
+      at: {
+        x: coordinates.viewport.x,
+        y: coordinates.viewport.y,
+      },
+      id: foregroundData.id,
+    }];
+  },
+};
+
+export default miningRockStrategy;

--- a/server/core/context-menu/strategies/open-screen.js
+++ b/server/core/context-menu/strategies/open-screen.js
@@ -1,0 +1,48 @@
+import UI from '#shared/ui.js';
+
+const openScreenStrategy = {
+  actionIds: ['player:screen:bank', 'player:screen:npc:trade'],
+  description: 'Open banking or trading panes from world interactions.',
+  canExecute: ({ menu, foregroundData, npcs }) => (
+    menu.isFromGameCanvas()
+      && (Boolean(foregroundData) || (Array.isArray(npcs) && npcs.length > 0))
+  ),
+  execute: ({ action, menu, foregroundData, npcs }) => {
+    if (!menu.isFromGameCanvas()) {
+      return [];
+    }
+
+    const results = [];
+
+    if (foregroundData && menu.canDoAction(foregroundData.actions, action)) {
+      const fgColor = UI.getContextSubjectColor(foregroundData.context);
+      results.push({
+        label: `${action.name} <span style='color:${fgColor}'>${foregroundData.name}</span>`,
+        action,
+        examine: foregroundData.examine,
+        type: 'foreground',
+        id: foregroundData.id,
+      });
+    }
+
+    if (Array.isArray(npcs)) {
+      npcs.forEach((npc) => {
+        if (!menu.canDoAction(npc.actions, action)) {
+          return;
+        }
+        const color = UI.getContextSubjectColor(npc.context);
+        results.push({
+          label: `${action.name} <span style='color:${color}'>${npc.name}</span>`,
+          action,
+          examine: npc.examine,
+          type: 'npc',
+          id: npc.id,
+        });
+      });
+    }
+
+    return results;
+  },
+};
+
+export default openScreenStrategy;

--- a/server/core/context-menu/strategies/registry.js
+++ b/server/core/context-menu/strategies/registry.js
@@ -1,0 +1,60 @@
+import bankActionStrategy from './bank-action.js';
+import cancelStrategy from './cancel.js';
+import equipStrategy from './equip.js';
+import examineStrategy from './examine.js';
+import inventoryDropStrategy from './inventory-drop.js';
+import miningRockStrategy from './mining-rock.js';
+import openScreenStrategy from './open-screen.js';
+import resourcePaneStrategy from './resource-pane.js';
+import smeltActionStrategy from './smelt-action.js';
+import takeStrategy from './take.js';
+import tradeActionStrategy from './trade-action.js';
+import unequipStrategy from './unequip.js';
+import walkHereStrategy from './walk-here.js';
+
+const strategies = [
+  cancelStrategy,
+  walkHereStrategy,
+  inventoryDropStrategy,
+  takeStrategy,
+  equipStrategy,
+  unequipStrategy,
+  examineStrategy,
+  miningRockStrategy,
+  smeltActionStrategy,
+  resourcePaneStrategy,
+  openScreenStrategy,
+  bankActionStrategy,
+  tradeActionStrategy,
+];
+
+const registry = new Map();
+
+strategies.forEach((strategy) => {
+  const { actionIds } = strategy;
+  if (!Array.isArray(actionIds)) {
+    return;
+  }
+
+  actionIds.forEach((actionId) => {
+    registry.set(actionId, strategy);
+  });
+});
+
+const actionCatalog = strategies.reduce((catalog, strategy) => {
+  const description = strategy.description || '';
+  if (!Array.isArray(strategy.actionIds)) {
+    return catalog;
+  }
+
+  strategy.actionIds.forEach((actionId) => {
+    catalog[actionId] = description;
+  });
+
+  return catalog;
+}, {});
+
+const getStrategy = actionId => registry.get(actionId);
+
+export { strategies as contextMenuStrategies, actionCatalog, getStrategy };
+export default registry;

--- a/server/core/context-menu/strategies/resource-pane.js
+++ b/server/core/context-menu/strategies/resource-pane.js
@@ -1,0 +1,34 @@
+import UI from '#shared/ui.js';
+
+const resourcePaneStrategy = {
+  actionIds: [
+    'player:resource:goldenplaque:push',
+    'player:resource:smelt:furnace:pane',
+    'player:resource:smith:anvil:pane',
+  ],
+  description: 'Open or interact with specialised resource panes.',
+  canExecute: ({ foregroundData, menu, action }) => (
+    Boolean(foregroundData)
+      && menu.canDoAction(foregroundData, action)
+  ),
+  execute: ({ action, foregroundData, coordinates, menu }) => {
+    if (!foregroundData) {
+      return [];
+    }
+
+    const color = UI.getContextSubjectColor(foregroundData.context);
+    return [{
+      label: `${action.name} <span style='color:${color}'>${foregroundData.name}</span>`,
+      action,
+      type: 'object',
+      at: {
+        x: coordinates.viewport.x,
+        y: coordinates.viewport.y,
+      },
+      id: foregroundData.id,
+      tile: menu.tile,
+    }];
+  },
+};
+
+export default resourcePaneStrategy;

--- a/server/core/context-menu/strategies/smelt-action.js
+++ b/server/core/context-menu/strategies/smelt-action.js
@@ -1,0 +1,28 @@
+import UI from '#shared/ui.js';
+
+const smeltActionStrategy = {
+  actionIds: ['player:resource:smelt:furnace:action', 'player:resource:smelt:anvil:action'],
+  description: 'Process resources using furnace or anvil panes.',
+  canExecute: ({ menu, selectedItemData }) => (
+    (menu.clickedOn('furnaceSlot') || menu.clickedOn('anvilSlot'))
+      && Boolean(selectedItemData)
+  ),
+  execute: ({ action, menu, miscData, selectedItemData }) => {
+    if (!selectedItemData || !menu.canDoAction(selectedItemData.actions, action)) {
+      return [];
+    }
+
+    const color = UI.getContextSubjectColor(selectedItemData.context);
+
+    return [{
+      label: `${action.name} <span style='color:${color}'>${selectedItemData.name}</span>`,
+      action,
+      type: 'item',
+      miscData,
+      uuid: selectedItemData.uuid,
+      id: selectedItemData.id,
+    }];
+  },
+};
+
+export default smeltActionStrategy;

--- a/server/core/context-menu/strategies/take.js
+++ b/server/core/context-menu/strategies/take.js
@@ -1,0 +1,40 @@
+import UI from '#shared/ui.js';
+import Query from '#server/core/data/query.js';
+
+const takeStrategy = {
+  actionIds: ['player:take'],
+  description: 'Pick up an item from the ground.',
+  canExecute: ({ groundItems }) => Array.isArray(groundItems) && groundItems.length > 0,
+  execute: ({ action, groundItems, menu }) => {
+    if (!Array.isArray(groundItems)) {
+      return [];
+    }
+
+    return groundItems.reduce((accumulator, item) => {
+      const baseData = Query.getItemData(item.id) || {};
+      const combined = { ...baseData, ...item };
+      const {
+        actions, name, x, y, id, uuid, timestamp,
+      } = combined;
+
+      if (!menu.canDoAction(actions, action)) {
+        return accumulator;
+      }
+
+      const color = UI.getContextSubjectColor(item.context);
+      accumulator.push({
+        label: `${action.name} <span style='color:${color}'>${name}</span>`,
+        action,
+        type: 'item',
+        at: { x, y },
+        id,
+        uuid,
+        timestamp,
+      });
+
+      return accumulator;
+    }, []);
+  },
+};
+
+export default takeStrategy;

--- a/server/core/context-menu/strategies/trade-action.js
+++ b/server/core/context-menu/strategies/trade-action.js
@@ -1,0 +1,30 @@
+import UI from '#shared/ui.js';
+
+const quantities = [1, 5, 10, 50];
+
+const tradeActionStrategy = {
+  actionIds: ['player:screen:npc:trade:action'],
+  description: 'Buy or sell items with shopkeepers in fixed quantities.',
+  canExecute: ({ menu, selectedItemData }) => (
+    (menu.clickedOn('shopSlot') || menu.clickedOn('inventorySlot'))
+      && Boolean(selectedItemData)
+  ),
+  execute: ({ action, menu, selectedItemData }) => {
+    if (!selectedItemData || !menu.canDoAction(selectedItemData.actions, action)) {
+      return [];
+    }
+
+    const color = UI.getContextSubjectColor(selectedItemData.context);
+
+    return quantities.map((quantity) => ({
+      label: `${action.name}-${quantity.toString()} <span style='color:${color}'>${selectedItemData.name}</span>`,
+      params: { quantity },
+      action,
+      examine: selectedItemData.examine,
+      type: 'item',
+      id: selectedItemData.id,
+    }));
+  },
+};
+
+export default tradeActionStrategy;

--- a/server/core/context-menu/strategies/unequip.js
+++ b/server/core/context-menu/strategies/unequip.js
@@ -1,0 +1,40 @@
+import UI from '#shared/ui.js';
+import Query from '#server/core/data/query.js';
+
+const unequipStrategy = {
+  actionIds: ['item:unequip'],
+  description: 'Unequip an item from the equipment screen.',
+  canExecute: ({ menu, miscData }) => (
+    menu.clickedOn('wearSlot')
+      && menu.isFromInventory()
+      && menu.player.wear
+      && Boolean(menu.player.wear[miscData.slot])
+  ),
+  execute: ({ action, menu, miscData }) => {
+    const wearSlot = menu.player.wear && menu.player.wear[miscData.slot];
+    if (!wearSlot) {
+      return [];
+    }
+
+    const baseData = Query.getItemData(wearSlot.id);
+    if (!baseData || !menu.canDoAction(baseData.actions, action)) {
+      return [];
+    }
+
+    const {
+      name, context, id, uuid,
+    } = baseData;
+    const color = UI.getContextSubjectColor(context);
+
+    return [{
+      label: `${action.name} <span style='color:${color}'>${name}</span>`,
+      action,
+      type: 'item',
+      miscData,
+      id,
+      uuid,
+    }];
+  },
+};
+
+export default unequipStrategy;

--- a/server/core/context-menu/strategies/walk-here.js
+++ b/server/core/context-menu/strategies/walk-here.js
@@ -1,0 +1,11 @@
+const walkHereStrategy = {
+  actionIds: ['player:walk-here'],
+  description: 'Move the player to the clicked tile.',
+  canExecute: () => true,
+  execute: ({ action }) => [{
+    action,
+    label: action.name,
+  }],
+};
+
+export default walkHereStrategy;

--- a/tests/unit/context-menu.spec.js
+++ b/tests/unit/context-menu.spec.js
@@ -1,0 +1,172 @@
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest';
+
+const mockUI = {
+  getTileOverMouse: vi.fn(() => null),
+  getContextSubjectColor: vi.fn(() => 'inherit'),
+};
+
+vi.mock('#shared/ui.js', () => ({
+  default: mockUI,
+}));
+
+const mockQuery = {
+  getItemData: vi.fn(),
+  getForegroundData: vi.fn(() => null),
+};
+
+vi.mock('#server/core/data/query.js', () => ({
+  default: mockQuery,
+}));
+
+import ContextMenu, { actionCatalog } from '#server/core/context-menu.js';
+import world from '#server/core/world.js';
+
+const DEFAULT_ACTIONS = [
+  'drop',
+  'equip',
+  'examine',
+  'take',
+  'mine',
+  'smelt',
+  'deposit',
+  'withdraw',
+  'buy',
+  'sell',
+];
+
+const createBaseItem = (id) => ({
+  id,
+  uuid: `item-${id}`,
+  name: `Item ${id}`,
+  examine: `Examine ${id}`,
+  context: 'item',
+  actions: [...DEFAULT_ACTIONS],
+});
+
+let player;
+
+beforeEach(() => {
+  mockUI.getTileOverMouse.mockReturnValue(null);
+  mockUI.getContextSubjectColor.mockImplementation(() => 'inherit');
+  mockQuery.getItemData.mockImplementation(id => createBaseItem(id));
+  mockQuery.getForegroundData.mockReturnValue(null);
+
+  world.players.splice(0, world.players.length);
+  world.npcs = [];
+  world.items = [];
+  world.shops = [];
+  world.map = { foreground: [], background: [] };
+
+  player = {
+    socket_id: 'socket-1',
+    uuid: 'player-1',
+    x: 10,
+    y: 10,
+    inventory: { slots: [] },
+    bank: [],
+    wear: [],
+    currentPane: null,
+    currentPaneData: null,
+  };
+
+  world.addPlayer(player);
+});
+
+afterEach(() => {
+  mockUI.getTileOverMouse.mockReset();
+  mockUI.getContextSubjectColor.mockReset();
+  mockQuery.getItemData.mockReset();
+  mockQuery.getForegroundData.mockReset();
+
+  world.players.splice(0, world.players.length);
+  world.npcs = [];
+  world.items = [];
+  world.shops = [];
+});
+
+describe('ContextMenu strategies', () => {
+  const tile = { x: 7, y: 5 };
+
+  it('includes the walk-here option when clicking on the game map', async () => {
+    const miscData = { clickedOn: { 0: 'gameMap' } };
+    const menu = new ContextMenu(player, tile, miscData);
+    const actions = await menu.build();
+
+    const walkHere = actions.find(entry => entry.action.actionId === 'player:walk-here');
+    expect(walkHere).toBeTruthy();
+    expect(walkHere.label).toBe('Walk here');
+  });
+
+  it('creates a drop action using dynamic item data from the inventory slot', async () => {
+    player.inventory.slots = [{
+      slot: 0,
+      id: 1,
+      name: 'Dynamic Item',
+      uuid: 'dynamic-uuid',
+    }];
+
+    const miscData = {
+      clickedOn: { 0: 'inventorySlot' },
+      slot: 0,
+    };
+
+    const menu = new ContextMenu(player, tile, miscData);
+    const actions = await menu.build();
+
+    const dropAction = actions.find(entry => entry.action.actionId === 'player:inventory-drop');
+    expect(dropAction).toBeTruthy();
+    expect(dropAction.uuid).toBe('dynamic-uuid');
+    expect(dropAction.label).toContain('Dynamic Item');
+    expect(dropAction.type).toBe('item');
+  });
+
+  it('produces take options for ground items at the clicked location', async () => {
+    world.items = [{
+      id: 2,
+      x: player.x,
+      y: player.y,
+      uuid: 'ground-uuid',
+      timestamp: 123,
+    }];
+
+    const miscData = { clickedOn: { 0: 'gameMap' } };
+    const menu = new ContextMenu(player, tile, miscData);
+    const actions = await menu.build();
+
+    const takeActions = actions.filter(entry => entry.action.actionId === 'player:take');
+    expect(takeActions).toHaveLength(1);
+    expect(takeActions[0].id).toBe(2);
+    expect(takeActions[0].uuid).toBe('ground-uuid');
+    expect(takeActions[0].type).toBe('item');
+  });
+
+  it('generates bank quantity options while on the bank pane', async () => {
+    player.currentPane = 'bank';
+    player.inventory.slots = [{ slot: 0, id: 3 }];
+
+    const miscData = {
+      clickedOn: { 0: 'inventorySlot' },
+      slot: 0,
+    };
+
+    const menu = new ContextMenu(player, tile, miscData);
+    const actions = await menu.build();
+
+    const bankActions = actions.filter(entry => entry.action.actionId === 'player:screen:bank:action');
+    expect(bankActions).toHaveLength(4);
+    expect(bankActions.map(entry => entry.params.quantity)).toEqual([1, 5, 10, 'All']);
+  });
+
+  it('exposes an action catalog entry for each strategy', () => {
+    expect(actionCatalog['player:inventory-drop']).toContain('Drop');
+    expect(actionCatalog['player:walk-here']).toContain('Move');
+    expect(actionCatalog['player:screen:bank:action']).toContain('Transfer');
+  });
+});


### PR DESCRIPTION
## Summary
- replace the massive switch in the context menu builder with a registry-driven strategy system
- add dedicated strategy modules with a shared canExecute/execute interface and expose an action catalog
- add targeted unit tests covering representative context menu behaviors

## Testing
- npm run test:unit -- tests/unit/context-menu.spec.js *(fails: jsdom dependency is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_69011c8770b08321b1a74583e4398ade