### PR TITLE
Refactor game server intervals into central scheduler

### DIFF
--- a/server/Delaford.js
+++ b/server/Delaford.js
@@ -9,6 +9,7 @@ import Monster from '#server/core/monster.js';
 import Socket from '#server/socket.js';
 import * as emoji from 'node-emoji';
 import { v4 as uuid } from 'uuid';
+import { performance } from 'node:perf_hooks';
 import world from '#server/core/world.js';
 import { partyService } from '#server/player/handlers/party.js';
 
@@ -23,6 +24,13 @@ class Delaford {
     // Load the map and spawn the default entities
     this.constructor.loadMap();
     this.loadEntities();
+
+    this.loopHandle = null;
+    this.loopLastTick = 0;
+    this.loopInterval = Number(process.env.GAME_LOOP_INTERVAL_MS) || 100;
+    this.schedulerLogInterval = Number(process.env.GAME_LOOP_LOG_INTERVAL_MS) || 10000;
+    this.schedulerStats = { tickCount: 0, totalDelta: 0, maxDelta: 0, lastLog: performance.now() };
+    this.periodicTasks = [];
   }
 
   /**
@@ -45,18 +53,8 @@ class Delaford {
    * Create the new server with the port
    */
   start() {
-    setInterval(() => {
-      NPC.movement();
-    }, 2000);
-
-    setInterval(() => {
-      Monster.tick();
-    }, 600);
-
-    setInterval(() => {
-      Item.check();
-      Item.resourcesCheck();
-    }, 1000);
+    this.registerPeriodicTasks();
+    this.startGameLoop();
 
     // Bind the websocket connection to the `this` context
     world.socket.ws.on('connection', this.connection.bind(this));
@@ -95,6 +93,97 @@ class Delaford {
         console.log(err);
       }
     }
+  }
+
+  registerPeriodicTasks() {
+    if (this.periodicTasks.length > 0) {
+      return;
+    }
+
+    this.addPeriodicTask('npc:movement', 2000, () => NPC.movement());
+    this.addPeriodicTask('monster:tick', 600, () => Monster.tick());
+    this.addPeriodicTask('items:tick', 1000, () => {
+      Item.check();
+      Item.resourcesCheck();
+    });
+  }
+
+  addPeriodicTask(name, interval, handler) {
+    this.periodicTasks.push({
+      name,
+      interval,
+      handler,
+      accumulator: 0,
+    });
+  }
+
+  startGameLoop() {
+    if (this.loopHandle) {
+      return;
+    }
+
+    this.loopLastTick = performance.now();
+
+    const tick = () => {
+      const now = performance.now();
+      const delta = now - this.loopLastTick;
+      this.loopLastTick = now;
+
+      this.updatePeriodicTasks(delta);
+      this.logSchedulerStats(delta, now);
+
+      this.loopHandle = setTimeout(tick, this.loopInterval);
+    };
+
+    this.loopHandle = setTimeout(tick, this.loopInterval);
+  }
+
+  updatePeriodicTasks(delta) {
+    this.periodicTasks.forEach((task) => {
+      task.accumulator += delta;
+
+      if (task.accumulator < task.interval) {
+        return;
+      }
+
+      const executions = Math.floor(task.accumulator / task.interval);
+      task.accumulator -= executions * task.interval;
+
+      for (let i = 0; i < executions; i += 1) {
+        try {
+          const result = task.handler(delta);
+
+          if (result && typeof result.then === 'function') {
+            result.catch((err) => console.error(`[Scheduler] Task ${task.name} rejected`, err));
+          }
+        } catch (err) {
+          console.error(`[Scheduler] Task ${task.name} failed`, err);
+        }
+      }
+    });
+  }
+
+  logSchedulerStats(delta, now) {
+    this.schedulerStats.tickCount += 1;
+    this.schedulerStats.totalDelta += delta;
+    this.schedulerStats.maxDelta = Math.max(this.schedulerStats.maxDelta, delta);
+
+    if ((now - this.schedulerStats.lastLog) < this.schedulerLogInterval) {
+      return;
+    }
+
+    const averageDelta = this.schedulerStats.totalDelta / this.schedulerStats.tickCount;
+    const cadence = 1000 / Math.max(averageDelta, 0.0001);
+
+    console.log(
+      `${emoji.get('alarm_clock')}  Scheduler cadence: avg ${averageDelta.toFixed(2)}ms/tick (${cadence.toFixed(2)} Hz), `
+      + `max ${this.schedulerStats.maxDelta.toFixed(2)}ms over ${this.schedulerStats.tickCount} ticks.`,
+    );
+
+    this.schedulerStats.tickCount = 0;
+    this.schedulerStats.totalDelta = 0;
+    this.schedulerStats.maxDelta = 0;
+    this.schedulerStats.lastLog = now;
   }
 
   /**


### PR DESCRIPTION
## Description
- replace the scattered `setInterval` timers with a central scheduler driven by delta-timed loop ticks
- add reusable registration for periodic tasks covering NPC movement, monster ticks, and resource checks
- report scheduler cadence and drift on a configurable interval to aid load profiling

## Related Issue
- N/A

## Motivation and Context
- centralizing timing logic improves consistency and makes it easier to monitor how the game loop performs under load

## How Has This Been Tested?
- Not run (in-container environment)

## Screenshots (if appropriate):
- N/A

## Types of change
- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


------
https://chatgpt.com/codex/tasks/task_e_6901252071448321aec4a74165026222