### PR TITLE
feat: overhaul inventory grid interactions

### DIFF
--- a/src/components/inventory/ContainerStack.vue
+++ b/src/components/inventory/ContainerStack.vue
@@ -1,0 +1,122 @@
+<template>
+  <div class="container-stack">
+    <header>
+      <h3>Containers</h3>
+      <p v-if="!containers.length">Drag a bag or cube here to open its storage.</p>
+    </header>
+
+    <ul v-if="containers.length" class="container-stack__list">
+      <li
+        v-for="entry in containers"
+        :key="entry.item.uuid"
+        class="container-stack__entry"
+      >
+        <div class="container-stack__meta">
+          <strong>{{ entry.item.name || 'Unknown Container' }}</strong>
+          <span class="container-stack__timestamp">Opened {{ formatTime(entry.openedAt) }}</span>
+        </div>
+        <span class="container-stack__status">Coming soon</span>
+      </li>
+    </ul>
+  </div>
+</template>
+
+<script>
+import { inject, computed } from 'vue';
+
+export default {
+  name: 'ContainerStack',
+  setup() {
+    const inventoryStore = inject('inventoryDragStore', null);
+
+    const formatTime = (timestamp) => {
+      const delta = Date.now() - timestamp;
+      const seconds = Math.max(1, Math.round(delta / 1000));
+      if (seconds < 60) {
+        return `${seconds}s ago`;
+      }
+
+      const minutes = Math.round(seconds / 60);
+      if (minutes < 60) {
+        return `${minutes}m ago`;
+      }
+
+      const hours = Math.round(minutes / 60);
+      return `${hours}h ago`;
+    };
+
+    const containers = computed(() => (
+      inventoryStore ? inventoryStore.containerStack.value : []
+    ));
+
+    return {
+      containers,
+      formatTime,
+    };
+  },
+};
+</script>
+
+<style lang="scss" scoped>
+.container-stack {
+  margin-top: 16px;
+  padding: 12px 14px;
+  background: rgba(0, 0, 0, 0.25);
+  border-radius: 6px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  color: rgba(255, 255, 255, 0.86);
+}
+
+.container-stack header {
+  margin-bottom: 8px;
+}
+
+.container-stack h3 {
+  margin: 0;
+  font-size: 14px;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+}
+
+.container-stack p {
+  margin: 4px 0 0 0;
+  font-size: 12px;
+  color: rgba(255, 255, 255, 0.6);
+}
+
+.container-stack__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 8px;
+}
+
+.container-stack__entry {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 8px 10px;
+  border-radius: 4px;
+  background: rgba(0, 0, 0, 0.35);
+  border: 1px dashed rgba(255, 255, 255, 0.12);
+}
+
+.container-stack__meta {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.container-stack__timestamp {
+  font-size: 11px;
+  color: rgba(255, 255, 255, 0.5);
+}
+
+.container-stack__status {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: rgba(255, 255, 255, 0.45);
+}
+</style>

--- a/src/components/inventory/InventoryGrid.vue
+++ b/src/components/inventory/InventoryGrid.vue
@@ -1,0 +1,357 @@
+<template>
+  <div
+    ref="gridRef"
+    class="inventory-grid"
+    :style="gridStyle"
+    @pointermove.prevent="handlePointerMove"
+    @pointerleave="handlePointerLeave"
+  >
+    <div
+      v-for="slotIndex in totalSlots"
+      :key="slotIndex"
+      class="inventory-grid__cell"
+    />
+
+    <transition-group name="inventory-item">
+      <div
+        v-for="item in items"
+        :key="item.uuid"
+        :class="['inventory-item', { 'inventory-item--dragging': isItemDragging(item.uuid) }]"
+        :style="itemStyle(item)"
+        @pointerdown.prevent="beginPointerDrag($event, item)"
+      >
+        <div
+          class="inventory-item__sprite"
+          :style="itemSpriteStyle(item)"
+        />
+        <span
+          v-if="item.stackable && item.qty > 1"
+          class="inventory-item__quantity"
+        >{{ item.qty }}</span>
+      </div>
+    </transition-group>
+
+    <div
+      v-if="ghostPlacement"
+      class="inventory-grid__ghost"
+      :class="ghostClasses"
+      :style="ghostStyle"
+    />
+  </div>
+</template>
+
+<script>
+import { computed, onBeforeUnmount, onMounted, ref } from 'vue';
+import { storeToRefs } from 'pinia';
+
+import { CELL_GAP_PX, CELL_SIZE_PX } from '@/core/inventory/constants.js';
+import { coordsFromIndex } from '@/core/inventory/grid-math.js';
+import { getItemDimensions } from '@/core/inventory/footprint.js';
+import { useInventoryStore } from '@/stores/inventory.js';
+
+export default {
+  name: 'InventoryGrid',
+  emits: ['commit'],
+  props: {
+    images: {
+      type: Object,
+      required: true,
+    },
+    columns: {
+      type: Number,
+      required: true,
+    },
+    rows: {
+      type: Number,
+      required: true,
+    },
+  },
+  setup(props, { emit }) {
+    const gridRef = ref(null);
+    const inventoryStore = useInventoryStore();
+    const {
+      items,
+      dragState,
+      isDragging,
+      activeItem,
+    } = storeToRefs(inventoryStore);
+
+    const gridStyle = computed(() => ({
+      '--cell-size': `${CELL_SIZE_PX}px`,
+      '--cell-gap': `${CELL_GAP_PX}px`,
+      gridTemplateColumns: `repeat(${props.columns}, var(--cell-size))`,
+      gridAutoRows: 'var(--cell-size)',
+    }));
+
+    const totalSlots = computed(() => props.columns * props.rows);
+
+    const pointerCellFromEvent = (event) => {
+      const element = gridRef.value;
+      if (!element) {
+        return null;
+      }
+
+      const rect = element.getBoundingClientRect();
+      const offsetX = event.clientX - rect.left;
+      const offsetY = event.clientY - rect.top;
+
+      const cellSize = CELL_SIZE_PX + CELL_GAP_PX;
+      const x = Math.floor(offsetX / cellSize);
+      const y = Math.floor(offsetY / cellSize);
+
+      if (x < 0 || y < 0 || x >= props.columns || y >= props.rows) {
+        return null;
+      }
+
+      return { x, y };
+    };
+
+    const handlePointerMove = (event) => {
+      if (!isDragging.value) {
+        return;
+      }
+
+      const pointerCell = pointerCellFromEvent(event);
+      if (!pointerCell) {
+        return;
+      }
+
+      inventoryStore.updatePointerCell(pointerCell);
+    };
+
+    const handlePointerLeave = () => {
+      if (!isDragging.value) {
+        return;
+      }
+
+      inventoryStore.clearHoverTarget();
+    };
+
+    const handlePointerUp = (event) => {
+      if (!isDragging.value) {
+        return;
+      }
+
+      const pointerCell = pointerCellFromEvent(event);
+      if (pointerCell) {
+        inventoryStore.updatePointerCell(pointerCell);
+      }
+
+      const result = inventoryStore.commitDrop();
+      emit('commit', result);
+      window.removeEventListener('pointerup', handlePointerUp);
+    };
+
+    const beginPointerDrag = (event, item) => {
+      const cell = pointerCellFromEvent(event) || coordsFromIndex(item.slot, props.columns);
+      const offset = {
+        x: cell.x - item.position.x,
+        y: cell.y - item.position.y,
+      };
+
+      inventoryStore.beginDrag(item.uuid, 'inventory', { pointerOffset: offset });
+      window.addEventListener('pointerup', handlePointerUp);
+    };
+
+    const handleKeyUp = (event) => {
+      if (!isDragging.value) {
+        return;
+      }
+
+      if (event.key?.toLowerCase() === 'r') {
+        inventoryStore.rotateActiveItem();
+      }
+    };
+
+    onMounted(() => {
+      window.addEventListener('keyup', handleKeyUp);
+    });
+
+    onBeforeUnmount(() => {
+      window.removeEventListener('pointerup', handlePointerUp);
+      window.removeEventListener('keyup', handleKeyUp);
+    });
+
+    const itemStyle = (item) => {
+      const { width, height } = getItemDimensions(item, item.orientation);
+      return {
+        gridColumnStart: item.position.x + 1,
+        gridColumnEnd: `span ${width}`,
+        gridRowStart: item.position.y + 1,
+        gridRowEnd: `span ${height}`,
+      };
+    };
+
+    const backgroundSrc = (tileset) => {
+      if (!props.images) {
+        return '';
+      }
+
+      switch (tileset) {
+      case 'general':
+        return props.images.generalImage ? props.images.generalImage.src : '';
+      case 'jewelry':
+        return props.images.jewelryImage ? props.images.jewelryImage.src : '';
+      case 'armor':
+        return props.images.armorImage ? props.images.armorImage.src : '';
+      default:
+        return props.images.weaponsImage ? props.images.weaponsImage.src : '';
+      }
+    };
+
+    const itemSpriteStyle = (item) => {
+      const { graphics = {} } = item;
+      const { tileset = 'weapons', column = 0, row = 0 } = graphics;
+
+      return {
+        backgroundImage: `url(${backgroundSrc(tileset)})`,
+        backgroundPosition: `left -${column * 32}px top -${row * 32}px`,
+      };
+    };
+
+    const isItemDragging = (uuid) => inventoryStore.dragState.value.activeItemId === uuid;
+
+    const ghostPlacement = computed(() => {
+      if (!dragState.value.ghostPosition) {
+        return null;
+      }
+
+      const item = activeItem.value;
+      if (!item) {
+        return null;
+      }
+
+      return {
+        position: dragState.value.ghostPosition,
+        orientation: dragState.value.orientation,
+        valid: dragState.value.hoverTarget?.valid,
+      };
+    });
+
+    const ghostClasses = computed(() => ({
+      'inventory-grid__ghost--invalid': ghostPlacement.value && ghostPlacement.value.valid === false,
+    }));
+
+    const ghostStyle = computed(() => {
+      if (!ghostPlacement.value) {
+        return {};
+      }
+
+      const item = activeItem.value;
+      if (!item) {
+        return {};
+      }
+
+      const { width, height } = getItemDimensions(item, ghostPlacement.value.orientation);
+
+      return {
+        gridColumnStart: ghostPlacement.value.position.x + 1,
+        gridColumnEnd: `span ${width}`,
+        gridRowStart: ghostPlacement.value.position.y + 1,
+        gridRowEnd: `span ${height}`,
+      };
+    });
+
+    return {
+      gridRef,
+      items,
+      dragState,
+      gridStyle,
+      totalSlots,
+      handlePointerMove,
+      handlePointerLeave,
+      beginPointerDrag,
+      itemStyle,
+      itemSpriteStyle,
+      isItemDragging,
+      ghostPlacement,
+      ghostClasses,
+      ghostStyle,
+    };
+  },
+};
+</script>
+
+<style lang="scss" scoped>
+.inventory-grid {
+  position: relative;
+  display: grid;
+  gap: var(--cell-gap);
+  padding: var(--cell-gap);
+  background: rgba(0, 0, 0, 0.4);
+  border-radius: 6px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: inset 0 0 12px rgba(0, 0, 0, 0.65);
+  user-select: none;
+}
+
+.inventory-grid__cell {
+  width: var(--cell-size);
+  height: var(--cell-size);
+  background: rgba(0, 0, 0, 0.1);
+  border: 1px dashed rgba(255, 255, 255, 0.05);
+  box-sizing: border-box;
+}
+
+.inventory-item {
+  position: relative;
+  display: flex;
+  align-items: flex-end;
+  justify-content: flex-end;
+  width: 100%;
+  height: 100%;
+  cursor: grab;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(0, 0, 0, 0.45);
+  border-radius: 4px;
+  box-shadow: inset 0 0 6px rgba(0, 0, 0, 0.7);
+  transition: transform 0.12s ease;
+}
+
+.inventory-item--dragging {
+  opacity: 0.45;
+  cursor: grabbing;
+}
+
+.inventory-item__sprite {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-repeat: no-repeat;
+}
+
+.inventory-item__quantity {
+  position: relative;
+  margin: 4px;
+  padding: 2px 4px;
+  background: rgba(0, 0, 0, 0.6);
+  border-radius: 3px;
+  font-size: 12px;
+  color: #ffe28a;
+  text-shadow: 1px 1px 0 rgba(0, 0, 0, 0.6);
+}
+
+.inventory-grid__ghost {
+  pointer-events: none;
+  border: 2px dashed rgba(255, 255, 255, 0.35);
+  background: rgba(0, 255, 153, 0.08);
+}
+
+.inventory-grid__ghost--invalid {
+  border-color: rgba(255, 82, 82, 0.65);
+  background: rgba(255, 82, 82, 0.12);
+}
+
+.inventory-item-enter-active,
+.inventory-item-leave-active {
+  transition: opacity 0.15s ease, transform 0.15s ease;
+}
+
+.inventory-item-enter-from,
+.inventory-item-leave-to {
+  opacity: 0;
+  transform: scale(0.95);
+}
+</style>

--- a/src/components/inventory/WorldDropZone.vue
+++ b/src/components/inventory/WorldDropZone.vue
@@ -1,0 +1,67 @@
+<template>
+  <div
+    class="world-drop-zone"
+    :class="{ 'world-drop-zone--active': isActive }"
+    @pointerenter="handlePointerEnter"
+    @pointerleave="handlePointerLeave"
+  >
+    <span>Drop items here to place on the ground</span>
+  </div>
+</template>
+
+<script>
+import { inject, computed } from 'vue';
+
+export default {
+  name: 'WorldDropZone',
+  setup() {
+    const inventoryStore = inject('inventoryDragStore', null);
+
+    const isActive = computed(() => (
+      inventoryStore
+      && inventoryStore.dragState.value?.hoverTarget?.type === 'world-drop'
+    ));
+
+    const handlePointerEnter = () => {
+      if (!inventoryStore || !inventoryStore.isDragging.value) {
+        return;
+      }
+
+      inventoryStore.setHoverTarget({ type: 'world-drop' });
+    };
+
+    const handlePointerLeave = () => {
+      if (!inventoryStore || !inventoryStore.isDragging.value) {
+        return;
+      }
+
+      inventoryStore.clearHoverTarget();
+    };
+
+    return {
+      isActive,
+      handlePointerEnter,
+      handlePointerLeave,
+    };
+  },
+};
+</script>
+
+<style lang="scss" scoped>
+.world-drop-zone {
+  margin-top: 12px;
+  padding: 10px 14px;
+  border-radius: 6px;
+  background: rgba(0, 0, 0, 0.3);
+  border: 1px dashed rgba(255, 255, 255, 0.2);
+  text-align: center;
+  font-size: 13px;
+  color: rgba(255, 255, 255, 0.8);
+  transition: background 0.2s ease, border-color 0.2s ease;
+}
+
+.world-drop-zone--active {
+  background: rgba(255, 138, 101, 0.18);
+  border-color: rgba(255, 138, 101, 0.65);
+}
+</style>

--- a/src/core/inventory/collision.js
+++ b/src/core/inventory/collision.js
@@ -1,0 +1,88 @@
+import { DEFAULT_GRID } from './constants.js';
+import { createFootprint, getItemDimensions } from './footprint.js';
+
+const cellKey = ({ x, y }) => `${x},${y}`;
+
+export const buildOccupancyMap = (items, grid = DEFAULT_GRID) => {
+  const occupancy = new Map();
+
+  items.forEach((item) => {
+    const { position, orientation, uuid } = item;
+    const footprint = createFootprint(position, item, orientation);
+    footprint.forEach((cell) => {
+      if (cell.x < 0 || cell.y < 0 || cell.x >= grid.columns || cell.y >= grid.rows) {
+        return;
+      }
+
+      occupancy.set(cellKey(cell), uuid);
+    });
+  });
+
+  return occupancy;
+};
+
+export const getItemAtCell = (items, cell) => {
+  if (!cell) {
+    return null;
+  }
+
+  return items.find((item) => (
+    createFootprint(item.position, item, item.orientation)
+      .some(({ x, y }) => x === cell.x && y === cell.y)
+  )) || null;
+};
+
+export const clampFootprintWithinGrid = (position, item, grid = DEFAULT_GRID, orientation) => {
+  if (!position) {
+    return null;
+  }
+
+  const { width, height } = getItemDimensions(item, orientation ?? item.orientation);
+  const maxX = grid.columns - width;
+  const maxY = grid.rows - height;
+
+  if (position.x < 0 || position.y < 0 || position.x > maxX || position.y > maxY) {
+    return {
+      x: Math.max(0, Math.min(maxX, position.x)),
+      y: Math.max(0, Math.min(maxY, position.y)),
+    };
+  }
+
+  return position;
+};
+
+export const findBlockingItems = (items, candidatePosition, activeItem, grid = DEFAULT_GRID, orientation) => {
+  if (!candidatePosition) {
+    return [];
+  }
+
+  const footprint = createFootprint(candidatePosition, activeItem, orientation ?? activeItem.orientation);
+  const blockers = new Set();
+
+  for (let index = 0; index < footprint.length; index += 1) {
+    const cell = footprint[index];
+
+    if (cell.x < 0 || cell.y < 0 || cell.x >= grid.columns || cell.y >= grid.rows) {
+      blockers.add('out-of-bounds');
+      continue;
+    }
+
+    const occupant = getItemAtCell(items, cell);
+    if (occupant && occupant.uuid !== activeItem.uuid) {
+      blockers.add(occupant.uuid);
+    }
+  }
+
+  return Array.from(blockers);
+};
+
+export const canPlaceItem = (items, candidatePosition, activeItem, grid = DEFAULT_GRID, orientation) => {
+  const blockers = findBlockingItems(items, candidatePosition, activeItem, grid, orientation);
+  const isOutOfBounds = blockers.includes('out-of-bounds');
+
+  return {
+    valid: blockers.length === 0,
+    isOutOfBounds,
+    blockers: blockers.filter((entry) => entry !== 'out-of-bounds'),
+  };
+};

--- a/src/core/inventory/constants.js
+++ b/src/core/inventory/constants.js
@@ -1,0 +1,12 @@
+export const INVENTORY_COLUMNS = 12;
+export const INVENTORY_ROWS = 7;
+export const CELL_SIZE_PX = 32;
+export const CELL_GAP_PX = 3;
+
+export const DEFAULT_GRID = Object.freeze({
+  columns: INVENTORY_COLUMNS,
+  rows: INVENTORY_ROWS,
+});
+
+export const ORIENTATION_DEFAULT = 'default';
+export const ORIENTATION_ROTATED = 'rotated';

--- a/src/core/inventory/footprint.js
+++ b/src/core/inventory/footprint.js
@@ -1,0 +1,46 @@
+import { ORIENTATION_DEFAULT, ORIENTATION_ROTATED } from './constants.js';
+import { normaliseSize } from './grid-math.js';
+
+export const getItemBaseSize = (item) => normaliseSize(
+  item?.baseSize || item?.size || item?.dimensions || item?.graphicSize || 1,
+);
+
+export const getItemDimensions = (item, orientation = ORIENTATION_DEFAULT) => {
+  const baseSize = getItemBaseSize(item);
+
+  if (orientation === ORIENTATION_ROTATED) {
+    return {
+      width: baseSize.height,
+      height: baseSize.width,
+    };
+  }
+
+  return { ...baseSize };
+};
+
+export const createFootprint = (position, item, orientation = ORIENTATION_DEFAULT) => {
+  if (!position) {
+    return [];
+  }
+
+  const { x, y } = position;
+  const { width, height } = getItemDimensions(item, orientation);
+
+  const footprint = [];
+  for (let offsetY = 0; offsetY < height; offsetY += 1) {
+    for (let offsetX = 0; offsetX < width; offsetX += 1) {
+      footprint.push({ x: x + offsetX, y: y + offsetY });
+    }
+  }
+
+  return footprint;
+};
+
+export const rotateOrientation = (orientation = ORIENTATION_DEFAULT) => (
+  orientation === ORIENTATION_ROTATED ? ORIENTATION_DEFAULT : ORIENTATION_ROTATED
+);
+
+export const canRotateItem = (item) => {
+  const { width, height } = getItemBaseSize(item);
+  return width !== height;
+};

--- a/src/core/inventory/grid-math.js
+++ b/src/core/inventory/grid-math.js
@@ -1,0 +1,36 @@
+import { DEFAULT_GRID } from './constants.js';
+
+export const coordsFromIndex = (index, columns = DEFAULT_GRID.columns) => ({
+  x: index % columns,
+  y: Math.floor(index / columns),
+});
+
+export const indexFromCoords = (x, y, columns = DEFAULT_GRID.columns) => (y * columns) + x;
+
+export const normaliseSize = (size) => {
+  if (!size) {
+    return { width: 1, height: 1 };
+  }
+
+  if (Array.isArray(size)) {
+    const [width = 1, height = 1] = size;
+    return { width, height };
+  }
+
+  if (typeof size === 'object') {
+    const { width = 1, height = 1 } = size;
+    return { width, height };
+  }
+
+  const parsed = Number(size);
+  if (Number.isFinite(parsed) && parsed > 0) {
+    return { width: parsed, height: 1 };
+  }
+
+  return { width: 1, height: 1 };
+};
+
+export const clampCoords = (x, y, grid = DEFAULT_GRID) => ({
+  x: Math.max(0, Math.min(grid.columns - 1, x)),
+  y: Math.max(0, Math.min(grid.rows - 1, y)),
+});

--- a/src/core/inventory/normalise.js
+++ b/src/core/inventory/normalise.js
@@ -1,0 +1,60 @@
+import { coordsFromIndex, indexFromCoords, normaliseSize } from './grid-math.js';
+import { ORIENTATION_DEFAULT } from './constants.js';
+import { isStackableItem } from './stacking.js';
+
+const deriveUuid = (item) => {
+  if (item.uuid) {
+    return item.uuid;
+  }
+
+  if (item.instanceId) {
+    return item.instanceId;
+  }
+
+  const slotId = typeof item.slot === 'number' ? item.slot : 'floating';
+  return `${item.id || 'item'}-${slotId}-${Math.random().toString(16).slice(2, 8)}`;
+};
+
+const derivePosition = (item, grid) => {
+  if (item.position && typeof item.position.x === 'number' && typeof item.position.y === 'number') {
+    return { x: item.position.x, y: item.position.y };
+  }
+
+  if (typeof item.slot === 'number') {
+    return coordsFromIndex(item.slot, grid.columns);
+  }
+
+  return { x: 0, y: 0 };
+};
+
+const deriveSlot = (item, grid) => {
+  if (typeof item.slot === 'number') {
+    return item.slot;
+  }
+
+  if (item.position && typeof item.position.x === 'number' && typeof item.position.y === 'number') {
+    return indexFromCoords(item.position.x, item.position.y, grid.columns);
+  }
+
+  return 0;
+};
+
+export const normaliseInventoryItem = (item, grid, orientationMap = new Map()) => {
+  const uuid = deriveUuid(item);
+  const baseSize = normaliseSize(item.size || item.baseSize);
+  const orientation = orientationMap.get(uuid) || item.orientation || ORIENTATION_DEFAULT;
+  const position = derivePosition(item, grid);
+  const slot = deriveSlot(item, grid);
+  const stackable = isStackableItem(item);
+
+  return {
+    ...item,
+    uuid,
+    slot,
+    position,
+    baseSize,
+    orientation,
+    stackable,
+    qty: typeof item.qty === 'number' ? item.qty : (stackable ? 0 : 1),
+  };
+};

--- a/src/core/inventory/stacking.js
+++ b/src/core/inventory/stacking.js
@@ -1,0 +1,49 @@
+export const isStackableItem = (item) => {
+  if (!item) {
+    return false;
+  }
+
+  if (typeof item.stackable === 'boolean') {
+    return item.stackable;
+  }
+
+  if (item.maxStack && item.maxStack > 1) {
+    return true;
+  }
+
+  if (item.qty && item.qty > 1) {
+    return true;
+  }
+
+  return false;
+};
+
+export const canStackWith = (source, target) => {
+  if (!source || !target) {
+    return false;
+  }
+
+  if (!isStackableItem(source) || !isStackableItem(target)) {
+    return false;
+  }
+
+  if (source.id !== target.id) {
+    return false;
+  }
+  return true;
+};
+
+export const applyStacking = (source, target) => {
+  if (!canStackWith(source, target)) {
+    return null;
+  }
+
+  const maxStack = target.maxStack || source.maxStack || Infinity;
+  const combined = (target.qty || 0) + (source.qty || 0);
+  const newQty = Math.min(combined, maxStack);
+
+  return {
+    sourceRemainder: Math.max(0, combined - maxStack),
+    targetQty: newQty,
+  };
+};

--- a/src/stores/inventory.js
+++ b/src/stores/inventory.js
@@ -1,0 +1,289 @@
+import { defineStore } from 'pinia';
+import { computed, reactive } from 'vue';
+
+import { DEFAULT_GRID, ORIENTATION_DEFAULT } from '@/core/inventory/constants.js';
+import { normaliseInventoryItem } from '@/core/inventory/normalise.js';
+import { rotateOrientation, canRotateItem } from '@/core/inventory/footprint.js';
+import { buildOccupancyMap, canPlaceItem, clampFootprintWithinGrid, getItemAtCell } from '@/core/inventory/collision.js';
+import { canStackWith, applyStacking } from '@/core/inventory/stacking.js';
+import { indexFromCoords } from '@/core/inventory/grid-math.js';
+
+const cloneItems = (items) => items.map((item) => ({ ...item, position: { ...item.position } }));
+
+export const useInventoryStore = defineStore('inventoryGrid', () => {
+  const grid = reactive({ ...DEFAULT_GRID });
+  const orientationMap = reactive(new Map());
+  const state = reactive({
+    items: [],
+    equipment: {},
+    dragState: {
+      activeItemId: null,
+      source: null,
+      pointerOffset: { x: 0, y: 0 },
+      ghostPosition: null,
+      orientation: ORIENTATION_DEFAULT,
+      hoverTarget: null,
+    },
+    containerStack: [],
+  });
+
+  const setInventoryItems = (rawItems = []) => {
+    const snapshot = new Map(orientationMap);
+    orientationMap.clear();
+    state.items = cloneItems(rawItems.map((item) => {
+      const mapped = normaliseInventoryItem(item, grid, snapshot);
+      orientationMap.set(mapped.uuid, mapped.orientation);
+      return mapped;
+    }));
+  };
+
+  const activeItem = computed(() => (
+    state.dragState.activeItemId
+      ? state.items.find((item) => item.uuid === state.dragState.activeItemId) || null
+      : null
+  ));
+
+  const isDragging = computed(() => !!state.dragState.activeItemId);
+
+  const occupancy = computed(() => buildOccupancyMap(state.items));
+
+  const findItemByUuid = (uuid) => state.items.find((item) => item.uuid === uuid) || null;
+
+  const setEquipment = (wear = {}) => {
+    state.equipment = { ...wear };
+  };
+
+  const beginDrag = (uuid, source, { pointerOffset = { x: 0, y: 0 } } = {}) => {
+    const item = findItemByUuid(uuid);
+    if (!item) {
+      return;
+    }
+
+    state.dragState.activeItemId = uuid;
+    state.dragState.source = source;
+    state.dragState.pointerOffset = { ...pointerOffset };
+    state.dragState.ghostPosition = { ...item.position };
+    state.dragState.orientation = orientationMap.get(uuid) || item.orientation || ORIENTATION_DEFAULT;
+    state.dragState.hoverTarget = {
+      type: 'inventory',
+      position: { ...item.position },
+      valid: true,
+      blockers: [],
+    };
+  };
+
+  const updateGhostPosition = (position) => {
+    if (!isDragging.value) {
+      return;
+    }
+
+    const item = activeItem.value;
+    if (!item) {
+      return;
+    }
+
+    const clamped = clampFootprintWithinGrid(position, item, grid, state.dragState.orientation);
+    state.dragState.ghostPosition = clamped;
+
+    const blockers = canPlaceItem(
+      state.items,
+      clamped,
+      item,
+      grid,
+      state.dragState.orientation,
+    );
+
+    const occupant = getItemAtCell(
+      state.items.filter((i) => i.uuid !== item.uuid),
+      clamped,
+    );
+
+    let stackTarget = null;
+    if (occupant && canStackWith(item, occupant)) {
+      stackTarget = occupant.uuid;
+    }
+
+    state.dragState.hoverTarget = {
+      type: 'inventory',
+      position: clamped,
+      valid: blockers.valid || !!stackTarget,
+      blockers: blockers.blockers,
+      isOutOfBounds: blockers.isOutOfBounds,
+      stackTarget,
+    };
+  };
+
+  const updatePointerCell = (cell) => {
+    if (!isDragging.value || !cell) {
+      return;
+    }
+
+    const { pointerOffset } = state.dragState;
+    const nextPosition = {
+      x: cell.x - pointerOffset.x,
+      y: cell.y - pointerOffset.y,
+    };
+
+    updateGhostPosition(nextPosition);
+  };
+
+  const setHoverTarget = (target) => {
+    if (!isDragging.value) {
+      return;
+    }
+
+    state.dragState.hoverTarget = target;
+  };
+
+  const clearHoverTarget = () => {
+    if (!isDragging.value) {
+      return;
+    }
+
+    state.dragState.hoverTarget = null;
+  };
+
+  const rotateActiveItem = () => {
+    const item = activeItem.value;
+    if (!item || !canRotateItem(item)) {
+      return;
+    }
+
+    const nextOrientation = rotateOrientation(state.dragState.orientation);
+    state.dragState.orientation = nextOrientation;
+    orientationMap.set(item.uuid, nextOrientation);
+    updateGhostPosition(state.dragState.ghostPosition || item.position);
+  };
+
+  const cancelDrag = () => {
+    state.dragState.activeItemId = null;
+    state.dragState.source = null;
+    state.dragState.pointerOffset = { x: 0, y: 0 };
+    state.dragState.ghostPosition = null;
+    state.dragState.orientation = ORIENTATION_DEFAULT;
+    state.dragState.hoverTarget = null;
+  };
+
+  const commitDrop = () => {
+    const item = activeItem.value;
+    const { hoverTarget, orientation } = state.dragState;
+
+    if (!item || !hoverTarget) {
+      cancelDrag();
+      return { cancelled: true };
+    }
+
+    if (hoverTarget.type === 'inventory') {
+      if (!hoverTarget.valid) {
+        cancelDrag();
+        return { cancelled: true, reason: 'invalid-placement' };
+      }
+
+      if (hoverTarget.stackTarget) {
+        const stackTarget = findItemByUuid(hoverTarget.stackTarget);
+        const stacking = applyStacking(item, stackTarget);
+        if (stacking) {
+          stackTarget.qty = stacking.targetQty;
+          item.qty = stacking.sourceRemainder;
+          if (item.qty === 0) {
+            state.items = state.items.filter((entry) => entry.uuid !== item.uuid);
+            orientationMap.delete(item.uuid);
+          }
+        }
+      } else {
+        const nextItems = state.items.map((entry) => {
+          if (entry.uuid === item.uuid) {
+            const nextSlot = indexFromCoords(hoverTarget.position.x, hoverTarget.position.y, grid.columns);
+            orientationMap.set(item.uuid, orientation);
+            return {
+              ...entry,
+              slot: nextSlot,
+              position: { ...hoverTarget.position },
+              orientation,
+            };
+          }
+          return entry;
+        });
+        state.items = nextItems;
+      }
+
+      cancelDrag();
+      return {
+        cancelled: false,
+        type: hoverTarget.stackTarget ? 'stack' : 'move',
+        target: hoverTarget,
+        item,
+      };
+    }
+
+    if (hoverTarget.type === 'equipment') {
+      cancelDrag();
+      return {
+        cancelled: false,
+        type: 'equip',
+        slotId: hoverTarget.slotId,
+        item,
+      };
+    }
+
+    if (hoverTarget.type === 'world-drop') {
+      state.items = state.items.filter((entry) => entry.uuid !== item.uuid);
+      orientationMap.delete(item.uuid);
+      cancelDrag();
+      return {
+        cancelled: false,
+        type: 'world-drop',
+        item,
+      };
+    }
+
+    cancelDrag();
+    return { cancelled: true };
+  };
+
+  const isHoveringSlot = (slotId) => (
+    state.dragState.hoverTarget
+    && state.dragState.hoverTarget.type === 'equipment'
+    && state.dragState.hoverTarget.slotId === slotId
+  );
+
+  const openContainer = (containerItem) => {
+    if (!containerItem) {
+      return;
+    }
+
+    state.containerStack.push({
+      item: containerItem,
+      openedAt: Date.now(),
+    });
+  };
+
+  const closeContainer = (uuid) => {
+    state.containerStack = state.containerStack.filter((entry) => entry.item.uuid !== uuid);
+  };
+
+  return {
+    grid,
+    state,
+    items: computed(() => state.items),
+    equipment: computed(() => state.equipment),
+    isDragging,
+    activeItem,
+    occupancy,
+    dragState: computed(() => state.dragState),
+    containerStack: computed(() => state.containerStack),
+    setInventoryItems,
+    setEquipment,
+    beginDrag,
+    updatePointerCell,
+    updateGhostPosition,
+    setHoverTarget,
+    clearHoverTarget,
+    rotateActiveItem,
+    commitDrop,
+    cancelDrag,
+    isHoveringSlot,
+    openContainer,
+    closeContainer,
+  };
+});

--- a/tests/unit/inventory-system.spec.js
+++ b/tests/unit/inventory-system.spec.js
@@ -1,0 +1,89 @@
+/** @vitest-environment node */
+
+import { describe, expect, it } from 'vitest';
+
+import { normaliseInventoryItem } from '@/core/inventory/normalise.js';
+import { createFootprint, rotateOrientation, getItemDimensions } from '@/core/inventory/footprint.js';
+import { canPlaceItem } from '@/core/inventory/collision.js';
+import { applyStacking, canStackWith, isStackableItem } from '@/core/inventory/stacking.js';
+import { DEFAULT_GRID, ORIENTATION_DEFAULT, ORIENTATION_ROTATED } from '@/core/inventory/constants.js';
+
+const mockItem = (overrides = {}) => ({
+  id: 'mock-item',
+  slot: 0,
+  size: { width: 2, height: 1 },
+  graphics: { tileset: 'weapons', column: 0, row: 0 },
+  ...overrides,
+});
+
+describe('inventory footprint utilities', () => {
+  it('builds a footprint for a given item and position', () => {
+    const item = mockItem();
+    const footprint = createFootprint({ x: 2, y: 3 }, item, ORIENTATION_DEFAULT);
+    expect(footprint).toEqual([
+      { x: 2, y: 3 },
+      { x: 3, y: 3 },
+    ]);
+  });
+
+  it('swaps width and height when rotated', () => {
+    const item = mockItem({ size: { width: 1, height: 3 } });
+    const rotated = getItemDimensions(item, ORIENTATION_ROTATED);
+    expect(rotated).toEqual({ width: 3, height: 1 });
+  });
+});
+
+describe('inventory normalisation', () => {
+  it('derives slot coordinates and preserves uuid', () => {
+    const item = mockItem({ uuid: 'abc-123', slot: 5 });
+    const normalised = normaliseInventoryItem(item, DEFAULT_GRID);
+    expect(normalised.uuid).toBe('abc-123');
+    expect(normalised.position).toEqual({ x: 5 % DEFAULT_GRID.columns, y: Math.floor(5 / DEFAULT_GRID.columns) });
+    expect(normalised.baseSize).toEqual({ width: 2, height: 1 });
+  });
+});
+
+describe('collision detection', () => {
+  it('detects collisions against occupied cells', () => {
+    const active = mockItem({ uuid: 'moving', position: { x: 0, y: 0 } });
+    const blocking = mockItem({ uuid: 'blocking', position: { x: 1, y: 0 } });
+    const result = canPlaceItem([
+      active,
+      blocking,
+    ], { x: 1, y: 0 }, active, DEFAULT_GRID, ORIENTATION_DEFAULT);
+
+    expect(result.valid).toBe(false);
+    expect(result.blockers).toContain('blocking');
+  });
+
+  it('allows placement when rotated inside bounds', () => {
+    const active = mockItem({ uuid: 'moving', size: { width: 1, height: 3 } });
+    const rotated = rotateOrientation(ORIENTATION_DEFAULT);
+    const result = canPlaceItem([active], { x: 0, y: 0 }, active, DEFAULT_GRID, rotated);
+    expect(result.valid).toBe(true);
+  });
+});
+
+describe('stacking utilities', () => {
+  it('identifies stackable items via flags or qty', () => {
+    expect(isStackableItem({ stackable: true })).toBe(true);
+    expect(isStackableItem({ qty: 5 })).toBe(true);
+    expect(isStackableItem({})).toBe(false);
+  });
+
+  it('merges quantities within the max stack threshold', () => {
+    const source = { id: 'potion', qty: 5, stackable: true, maxStack: 10 };
+    const target = { id: 'potion', qty: 4, stackable: true, maxStack: 10 };
+    expect(canStackWith(source, target)).toBe(true);
+
+    const outcome = applyStacking(source, target);
+    expect(outcome).toEqual({ sourceRemainder: 0, targetQty: 9 });
+  });
+
+  it('returns remainder when exceeding max stack', () => {
+    const source = { id: 'potion', qty: 12, stackable: true, maxStack: 10 };
+    const target = { id: 'potion', qty: 4, stackable: true, maxStack: 10 };
+    const outcome = applyStacking(source, target);
+    expect(outcome).toEqual({ sourceRemainder: 6, targetQty: 10 });
+  });
+});

--- a/tests/unit/setup.js
+++ b/tests/unit/setup.js
@@ -1,13 +1,15 @@
-Object.defineProperty(window, 'matchMedia', {
-  writable: true,
-  value: (query) => ({
-    matches: false,
-    media: query,
-    onchange: null,
-    addListener: () => {},
-    removeListener: () => {},
-    addEventListener: () => {},
-    removeEventListener: () => {},
-    dispatchEvent: () => false,
-  }),
-});
+if (typeof window !== 'undefined') {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: (query) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: () => {},
+      removeListener: () => {},
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      dispatchEvent: () => false,
+    }),
+  });
+}


### PR DESCRIPTION
## Summary
- implement core inventory math utilities and a Pinia store to drive grid collision, rotation, and stacking logic
- replace the inventory pane with an interactive grid, equipment drop targets, world drop zone, and container stack scaffold
- cover the new helpers with focused unit tests and make the Vitest setup guard browser-only globals

## Testing
- npm run test:unit -- --run tests/unit/inventory-system.spec.js --environment node

------
https://chatgpt.com/codex/tasks/task_e_690128df1474832189f91c7632d1dacf