### PR TITLE
Implement skill schema, AI behaviors, and instance lifecycle

### DIFF
--- a/server/Delaford.js
+++ b/server/Delaford.js
@@ -106,6 +106,7 @@ class Delaford {
       Item.check();
       Item.resourcesCheck();
     });
+    this.addPeriodicTask('party:instances', 1500, () => partyService.evaluateInstances());
   }
 
   addPeriodicTask(name, interval, handler) {

--- a/server/core/entities/ai/ecs-lite.js
+++ b/server/core/entities/ai/ecs-lite.js
@@ -1,0 +1,73 @@
+const createEntity = (id) => ({
+  id,
+  components: new Map(),
+  addComponent(type, data) {
+    this.components.set(type, data);
+    return this;
+  },
+  getComponent(type) {
+    return this.components.get(type);
+  },
+  hasComponent(type) {
+    return this.components.has(type);
+  },
+  removeComponent(type) {
+    this.components.delete(type);
+    return this;
+  },
+});
+
+const createWorld = () => {
+  const entities = new Map();
+  const systems = [];
+  const worldContext = {
+    lastUpdateAt: null,
+  };
+
+  return {
+    entities,
+    systems,
+    context: worldContext,
+    createEntity(id) {
+      const entity = createEntity(id);
+      entities.set(id, entity);
+      return entity;
+    },
+    addEntity(entity) {
+      if (entity && entity.id) {
+        entities.set(entity.id, entity);
+      }
+      return entity;
+    },
+    removeEntity(id) {
+      entities.delete(id);
+    },
+    addSystem(system) {
+      if (typeof system === 'function') {
+        systems.push(system);
+      }
+      return system;
+    },
+    update(delta, context = {}) {
+      systems.forEach((system) => {
+        system(this, delta, context);
+      });
+    },
+    query(...componentTypes) {
+      const required = componentTypes.flat().filter(Boolean);
+      if (!required.length) {
+        return Array.from(entities.values());
+      }
+      return Array.from(entities.values()).filter((entity) => (
+        required.every((type) => entity.hasComponent(type))
+      ));
+    },
+  };
+};
+
+export { createWorld, createEntity };
+
+export default {
+  createWorld,
+  createEntity,
+};

--- a/server/core/entities/monster/ai-controller.js
+++ b/server/core/entities/monster/ai-controller.js
@@ -1,0 +1,45 @@
+import { createWorld } from '../ai/ecs-lite.js';
+import behaviourRegistry, { resolveBehaviour } from './behaviours/index.js';
+
+const createMonsterAIController = (monster) => {
+  const world = createWorld();
+  const entity = world.createEntity(monster.uuid);
+
+  entity.addComponent('monster', { ref: monster });
+  entity.addComponent('state', monster.state);
+  entity.addComponent('lifecycle', { dirty: false });
+  entity.addComponent('behaviour-config', monster.behaviour || {});
+  world.addEntity(entity);
+
+  const behaviourType = monster.behaviour && monster.behaviour.type
+    ? monster.behaviour.type
+    : 'melee';
+  const register = resolveBehaviour(behaviourType);
+  register({ world, entity, monster });
+
+  let lastUpdateAt = null;
+
+  return {
+    update(now = Date.now()) {
+      const delta = lastUpdateAt === null ? 0 : now - lastUpdateAt;
+      lastUpdateAt = now;
+      world.update(delta, { now });
+      const lifecycle = entity.getComponent('lifecycle');
+      const dirty = lifecycle ? Boolean(lifecycle.dirty) : false;
+      if (lifecycle) {
+        lifecycle.dirty = false;
+      }
+      return dirty;
+    },
+    setBehaviour(type) {
+      if (!type || !behaviourRegistry[type]) {
+        return;
+      }
+      entity.addComponent('behaviour-config', monster.behaviour || {});
+      world.systems.length = 0;
+      behaviourRegistry[type]({ world, entity, monster });
+    },
+  };
+};
+
+export default createMonsterAIController;

--- a/server/core/entities/monster/behaviours/index.js
+++ b/server/core/entities/monster/behaviours/index.js
@@ -1,0 +1,15 @@
+import registerMeleeBehaviour from './melee.js';
+import registerRangedBehaviour from './ranged.js';
+import registerSupportBehaviour from './support.js';
+
+const behaviourRegistry = {
+  melee: registerMeleeBehaviour,
+  ranged: registerRangedBehaviour,
+  support: registerSupportBehaviour,
+};
+
+export const resolveBehaviour = (type = 'melee') => (
+  behaviourRegistry[type] || behaviourRegistry.melee
+);
+
+export default behaviourRegistry;

--- a/server/core/entities/monster/behaviours/melee.js
+++ b/server/core/entities/monster/behaviours/melee.js
@@ -1,0 +1,93 @@
+import { euclideanDistance, manhattanDistance } from '../movement-handler.js';
+
+const markDirty = (entity, dirty) => {
+  if (!dirty) {
+    return false;
+  }
+  const lifecycle = entity.getComponent('lifecycle');
+  if (lifecycle) {
+    lifecycle.dirty = true;
+  }
+  return true;
+};
+
+const ensureRespawn = (monster, now) => {
+  if (monster.state.respawnAt && now < monster.state.respawnAt) {
+    return false;
+  }
+  monster.respawnNow(now);
+  return true;
+};
+
+const handleDeathState = (monster, entity, now) => {
+  if (!monster.state.respawnAt) {
+    monster.state.respawnAt = now + monster.respawn.delayMs;
+    return markDirty(entity, true);
+  }
+
+  if (now >= monster.state.respawnAt) {
+    return markDirty(entity, ensureRespawn(monster, now));
+  }
+
+  return false;
+};
+
+const createMeleeBehaviourSystem = (entity, monster) => (world, _delta, context = {}) => {
+  const now = context.now || Date.now();
+  const lifecycle = entity.getComponent('lifecycle');
+  if (lifecycle) {
+    lifecycle.dirty = false;
+  }
+
+  if (!monster.isAlive) {
+    handleDeathState(monster, entity, now);
+    return;
+  }
+
+  let dirty = false;
+
+  if (monster.state.pendingAttack && now >= monster.state.pendingAttack.resolveAt) {
+    dirty = monster.resolvePendingAttack(now) || dirty;
+  }
+
+  const target = monster.resolveTarget(now);
+  if (target) {
+    monster.state.mode = 'engaged';
+    const distance = manhattanDistance(monster, target);
+    if (distance <= 1) {
+      dirty = monster.tryAttack(target, now) || dirty;
+    } else {
+      dirty = monster.pursue(target, now) || dirty;
+    }
+    markDirty(entity, dirty);
+    return;
+  }
+
+  const distanceFromSpawn = euclideanDistance(monster, monster.spawn);
+  if (distanceFromSpawn > 0.5) {
+    monster.state.mode = 'returning';
+    dirty = monster.returnToSpawn(now) || dirty;
+    markDirty(entity, dirty);
+    return;
+  }
+
+  monster.state.mode = 'patrolling';
+  dirty = monster.patrol(now) || dirty;
+  markDirty(entity, dirty);
+};
+
+const registerMeleeBehaviour = ({ world, entity, monster }) => {
+  entity.addComponent('behaviour', { type: 'melee' });
+  if (!entity.hasComponent('lifecycle')) {
+    entity.addComponent('lifecycle', { dirty: false });
+  }
+  if (!entity.hasComponent('monster')) {
+    entity.addComponent('monster', { ref: monster });
+  }
+
+  const system = createMeleeBehaviourSystem(entity, monster);
+  world.addSystem(system);
+  return system;
+};
+
+export default registerMeleeBehaviour;

--- a/server/core/entities/monster/behaviours/ranged.js
+++ b/server/core/entities/monster/behaviours/ranged.js
@@ -1,0 +1,122 @@
+import { manhattanDistance } from '../movement-handler.js';
+
+const markDirty = (entity, dirty) => {
+  if (!dirty) {
+    return false;
+  }
+  const lifecycle = entity.getComponent('lifecycle');
+  if (lifecycle) {
+    lifecycle.dirty = true;
+  }
+  return true;
+};
+
+const attemptRetreat = (monster, target, now) => {
+  if (!target) {
+    return false;
+  }
+
+  const dx = monster.x - target.x;
+  const dy = monster.y - target.y;
+
+  const primaryDirection = Math.abs(dx) > Math.abs(dy)
+    ? (dx >= 0 ? 'right' : 'left')
+    : (dy >= 0 ? 'down' : 'up');
+
+  const fallback = primaryDirection === 'left' || primaryDirection === 'right'
+    ? ['up', 'down']
+    : ['left', 'right'];
+
+  const candidates = [primaryDirection, ...fallback];
+
+  for (let index = 0; index < candidates.length; index += 1) {
+    const direction = candidates[index];
+    if (direction && monster.step(direction, now)) {
+      return true;
+    }
+  }
+
+  return false;
+};
+
+const ensureDeathHandled = (monster, entity, now) => {
+  if (!monster.state.respawnAt) {
+    monster.state.respawnAt = now + monster.respawn.delayMs;
+    return markDirty(entity, true);
+  }
+  if (now >= monster.state.respawnAt) {
+    monster.respawnNow(now);
+    return markDirty(entity, true);
+  }
+  return false;
+};
+
+const createRangedBehaviourSystem = (entity, monster) => (world, _delta, context = {}) => {
+  const now = context.now || Date.now();
+  const lifecycle = entity.getComponent('lifecycle');
+  if (lifecycle) {
+    lifecycle.dirty = false;
+  }
+
+  if (!monster.isAlive) {
+    ensureDeathHandled(monster, entity, now);
+    return;
+  }
+
+  const behaviour = monster.behaviour || {};
+  const attackConfig = behaviour.attack || {};
+  const preferredRange = Math.max(2, attackConfig.range || 4);
+  const minimumDistance = Math.max(1, attackConfig.minimumRange || 2);
+
+  let dirty = false;
+
+  if (monster.state.pendingAttack && now >= monster.state.pendingAttack.resolveAt) {
+    dirty = monster.resolvePendingAttack(now) || dirty;
+  }
+
+  const target = monster.resolveTarget(now);
+  if (!target) {
+    monster.state.mode = 'patrolling';
+    dirty = monster.patrol(now) || dirty;
+    markDirty(entity, dirty);
+    return;
+  }
+
+  monster.state.mode = 'engaged';
+  const distance = manhattanDistance(monster, target);
+
+  if (distance <= preferredRange && distance > minimumDistance) {
+    dirty = monster.tryAttack(target, now) || dirty;
+    markDirty(entity, dirty);
+    return;
+  }
+
+  if (distance <= minimumDistance) {
+    const retreated = attemptRetreat(monster, target, now);
+    dirty = retreated || dirty;
+    if (!retreated) {
+      dirty = monster.tryAttack(target, now) || dirty;
+    }
+    markDirty(entity, dirty);
+    return;
+  }
+
+  dirty = monster.pursue(target, now) || dirty;
+  markDirty(entity, dirty);
+};
+
+const registerRangedBehaviour = ({ world, entity, monster }) => {
+  entity.addComponent('behaviour', { type: 'ranged' });
+  if (!entity.hasComponent('lifecycle')) {
+    entity.addComponent('lifecycle', { dirty: false });
+  }
+  if (!entity.hasComponent('monster')) {
+    entity.addComponent('monster', { ref: monster });
+  }
+
+  const system = createRangedBehaviourSystem(entity, monster);
+  world.addSystem(system);
+  return system;
+};
+
+export default registerRangedBehaviour;

--- a/server/core/entities/monster/behaviours/support.js
+++ b/server/core/entities/monster/behaviours/support.js
@@ -1,0 +1,148 @@
+import { manhattanDistance } from '../movement-handler.js';
+import { DEFAULT_BEHAVIOUR } from '../stats-manager.js';
+
+const markDirty = (entity, dirty) => {
+  if (!dirty) {
+    return false;
+  }
+  const lifecycle = entity.getComponent('lifecycle');
+  if (lifecycle) {
+    lifecycle.dirty = true;
+  }
+  return true;
+};
+
+const findWeakenedAlly = (monster) => {
+  const scene = monster.activeScene;
+  if (!scene || !Array.isArray(scene.monsters)) {
+    return null;
+  }
+
+  const candidates = scene.monsters
+    .filter((ally) => ally && ally.uuid !== monster.uuid && ally.isAlive)
+    .map((ally) => {
+      const health = ally.stats && ally.stats.resources ? ally.stats.resources.health : null;
+      const missing = health ? (health.max - health.current) : 0;
+      return { ally, missing };
+    })
+    .filter(entry => entry.missing > 0)
+    .sort((a, b) => b.missing - a.missing);
+
+  return candidates.length ? candidates[0].ally : null;
+};
+
+const applyHeal = (monster, ally, behaviour, now) => {
+  if (!ally) {
+    return false;
+  }
+
+  const supportConfig = behaviour.support || DEFAULT_BEHAVIOUR.support || {};
+  const healRange = supportConfig.healRange || 5;
+  const healAmount = supportConfig.healAmount || Math.round(monster.level * 3.5);
+
+  if (manhattanDistance(monster, ally) > healRange) {
+    return 'move';
+  }
+
+  const result = ally.heal(healAmount, { now });
+  if (result) {
+    monster.setAnimationState('attack', { direction: monster.facing, duration: behaviour.attack?.windupMs || 400, startedAt: now });
+    return 'healed';
+  }
+
+  return false;
+};
+
+const ensureDeathHandled = (monster, entity, now) => {
+  if (!monster.state.respawnAt) {
+    monster.state.respawnAt = now + monster.respawn.delayMs;
+    return markDirty(entity, true);
+  }
+  if (now >= monster.state.respawnAt) {
+    monster.respawnNow(now);
+    return markDirty(entity, true);
+  }
+  return false;
+};
+
+const createSupportBehaviourSystem = (entity, monster) => (world, _delta, context = {}) => {
+  const now = context.now || Date.now();
+  const lifecycle = entity.getComponent('lifecycle');
+  if (lifecycle) {
+    lifecycle.dirty = false;
+  }
+
+  if (!monster.isAlive) {
+    ensureDeathHandled(monster, entity, now);
+    return;
+  }
+
+  let dirty = false;
+
+  const behaviour = monster.behaviour || {};
+  const attackConfig = behaviour.attack || {};
+  const rangedPreferred = Math.max(3, attackConfig.range || 5);
+  const minimumDistance = Math.max(1, attackConfig.minimumRange || 2);
+
+  if (monster.state.pendingAttack && now >= monster.state.pendingAttack.resolveAt) {
+    dirty = monster.resolvePendingAttack(now) || dirty;
+  }
+
+  const ally = findWeakenedAlly(monster);
+  if (ally) {
+    monster.state.mode = 'support';
+    const action = applyHeal(monster, ally, behaviour, now);
+    if (action === 'move') {
+      dirty = monster.pursue(ally, now) || dirty;
+    } else if (action === 'healed') {
+      dirty = true;
+    }
+    markDirty(entity, dirty);
+    return;
+  }
+
+  const target = monster.resolveTarget(now);
+  if (!target) {
+    monster.state.mode = 'patrolling';
+    dirty = monster.patrol(now) || dirty;
+    markDirty(entity, dirty);
+    return;
+  }
+
+  monster.state.mode = 'engaged';
+  const distance = manhattanDistance(monster, target);
+
+  if (distance <= rangedPreferred && distance > minimumDistance) {
+    dirty = monster.tryAttack(target, now) || dirty;
+    markDirty(entity, dirty);
+    return;
+  }
+
+  if (distance <= minimumDistance) {
+    dirty = monster.pursue(target, now) || dirty;
+    if (!dirty) {
+      dirty = monster.tryAttack(target, now) || dirty;
+    }
+    markDirty(entity, dirty);
+    return;
+  }
+
+  dirty = monster.pursue(target, now) || dirty;
+  markDirty(entity, dirty);
+};
+
+const registerSupportBehaviour = ({ world, entity, monster }) => {
+  entity.addComponent('behaviour', { type: 'support' });
+  if (!entity.hasComponent('lifecycle')) {
+    entity.addComponent('lifecycle', { dirty: false });
+  }
+  if (!entity.hasComponent('monster')) {
+    entity.addComponent('monster', { ref: monster });
+  }
+
+  const system = createSupportBehaviourSystem(entity, monster);
+  world.addSystem(system);
+  return system;
+};
+
+export default registerSupportBehaviour;

--- a/server/core/entities/monster/stats-manager.js
+++ b/server/core/entities/monster/stats-manager.js
@@ -14,6 +14,7 @@ export const DEFAULT_RESPAWN = {
 };
 
 export const DEFAULT_BEHAVIOUR = {
+  type: 'melee',
   aggressionRange: 5,
   pursuitRange: 8,
   leash: 10,
@@ -24,6 +25,12 @@ export const DEFAULT_BEHAVIOUR = {
     intervalMs: 1600,
     windupMs: 300,
     damageMultiplier: 1,
+    range: 1,
+    minimumRange: 1,
+  },
+  support: {
+    healAmount: 14,
+    healRange: 5,
   },
 };
 
@@ -69,12 +76,28 @@ const buildBehaviour = (monster, overrides = {}) => {
     ...(overrides && overrides.attack ? overrides.attack : {}),
   };
 
+  merged.support = {
+    ...base.support,
+    ...(archetypeBehaviour && archetypeBehaviour.support ? archetypeBehaviour.support : {}),
+    ...(overrides && overrides.support ? overrides.support : {}),
+  };
+
+  merged.type = (overrides && overrides.type)
+    || (archetypeBehaviour && archetypeBehaviour.type)
+    || base.type
+    || 'melee';
+
   if (rarity && rarity.attackSpeedMultiplier) {
     merged.attack.intervalMs = Math.round(merged.attack.intervalMs * rarity.attackSpeedMultiplier);
   }
 
   merged.attack.intervalMs = Math.max(400, merged.attack.intervalMs || DEFAULT_BEHAVIOUR.attack.intervalMs);
   merged.attack.windupMs = Math.max(100, merged.attack.windupMs || DEFAULT_BEHAVIOUR.attack.windupMs);
+  merged.attack.range = Math.max(1, merged.attack.range || DEFAULT_BEHAVIOUR.attack.range || 1);
+  merged.attack.minimumRange = Math.max(0, merged.attack.minimumRange || DEFAULT_BEHAVIOUR.attack.minimumRange || 0);
+
+  merged.support.healAmount = Math.max(1, merged.support.healAmount || DEFAULT_BEHAVIOUR.support.healAmount);
+  merged.support.healRange = Math.max(1, merged.support.healRange || DEFAULT_BEHAVIOUR.support.healRange);
 
   merged.patrolRadius = Math.max(0, Number.isFinite(merged.patrolRadius) ? merged.patrolRadius : 0);
   merged.leash = Math.max(merged.patrolRadius, Number.isFinite(merged.leash) ? merged.leash : 0);

--- a/server/core/map.js
+++ b/server/core/map.js
@@ -147,6 +147,60 @@ class Map {
       });
     }
 
+    const monsterSpawns = carvedRooms.slice(1);
+    const roleCycle = ['melee', 'ranged', 'support'];
+    const instanceMonsters = monsterSpawns.map((center, index) => {
+      const role = roleCycle[index % roleCycle.length];
+      const behaviour = {
+        type: role,
+        aggressionRange: role === 'support' ? 6 : 8,
+        pursuitRange: role === 'melee' ? 9 : 11,
+        patrolRadius: 4,
+        attack: {
+          intervalMs: role === 'melee' ? 1500 : 1900,
+          windupMs: role === 'melee' ? 320 : 480,
+          damageMultiplier: role === 'support' ? 0.85 : 1.1,
+          range: role === 'melee' ? 1 : 5,
+          minimumRange: role === 'support' ? 2 : 1,
+        },
+      };
+
+      if (role === 'support') {
+        behaviour.support = {
+          healAmount: 20 + (index * 5),
+          healRange: 6,
+        };
+      }
+
+      const archetype = role === 'ranged' ? 'mystic' : (role === 'support' ? 'mystic' : 'brute');
+      const rarity = index % 3 === 2 ? 'rare' : (index % 3 === 1 ? 'uncommon' : 'common');
+
+      return {
+        id: `instance-${seed}-${index}`,
+        name: role === 'support'
+          ? 'Celestial Channeler'
+          : role === 'ranged'
+            ? 'Ashen Marksman'
+            : 'Dread Vanguard',
+        level: Math.max(4, Math.floor(5 + (index * 0.75))),
+        archetype,
+        rarity,
+        spawn: {
+          x: center.x,
+          y: center.y,
+          radius: 2,
+        },
+        behaviour,
+        rewards: {
+          experience: 30 + (index * 18),
+          coins: 60 + (index * 20),
+        },
+        respawn: {
+          delayMs: 600000,
+        },
+      };
+    });
+
     return {
       map: {
         background,
@@ -156,6 +210,13 @@ class Map {
         seed,
         template,
         spawnPoints: carvedRooms,
+        rewards: {
+          coinsPerPlayer: 120 + (instanceMonsters.length * 20),
+          experience: {
+            skill: 'attack',
+            amount: 40 + (instanceMonsters.length * 10),
+          },
+        },
       },
       respawns: {
         items: [],
@@ -164,7 +225,7 @@ class Map {
       },
       items: [],
       npcs: [],
-      monsters: [],
+      monsters: instanceMonsters,
     };
   }
 

--- a/server/shared/skills/index.js
+++ b/server/shared/skills/index.js
@@ -1,0 +1,137 @@
+import { DEFAULT_SKILL_IDS } from '../combat.js';
+import { createSkillDefinition, createQuickbarSlot } from './schema.js';
+
+const SKILL_DEFINITIONS = [
+  createSkillDefinition({
+    id: DEFAULT_SKILL_IDS.primary,
+    name: 'Blade Sweep',
+    label: 'Blade Sweep',
+    icon: '⚔️',
+    category: 'combat',
+    description: 'Deliver a quick melee strike in front of you.',
+    animation: { state: 'attack', duration: 420, holdState: 'idle' },
+    quickbar: { slot: 0, hotkey: '1', binding: DEFAULT_SKILL_IDS.primary, group: 'combat' },
+    modifiers: { globalCooldownMs: 350 },
+    tags: ['starter', 'melee'],
+  }),
+  createSkillDefinition({
+    id: DEFAULT_SKILL_IDS.dash,
+    name: 'Phantom Step',
+    label: 'Phantom Step',
+    icon: '💨',
+    category: 'mobility',
+    description: 'Dash a short distance in the direction you are facing.',
+    animation: { state: 'dash', duration: 320, holdState: 'run' },
+    quickbar: { slot: 1, hotkey: '2', binding: DEFAULT_SKILL_IDS.dash, group: 'movement' },
+    behaviour: { movement: { distance: 3 } },
+    cooldown: 8,
+    tags: ['movement'],
+  }),
+  createSkillDefinition({
+    id: DEFAULT_SKILL_IDS.ability1,
+    name: 'Ember Volley',
+    label: 'Ember Volley',
+    icon: '🔥',
+    category: 'combat',
+    description: 'Launch a spread of searing bolts that damages foes at range.',
+    animation: { state: 'attack', duration: 520, holdState: 'idle' },
+    quickbar: { slot: 2, hotkey: '3', group: 'ability' },
+    behaviour: { projectile: { range: 5, travelTimeMs: 280 } },
+    cooldown: 6,
+    resourceCost: { mana: 12 },
+    tags: ['ranged', 'burst'],
+  }),
+  createSkillDefinition({
+    id: DEFAULT_SKILL_IDS.ability2,
+    name: 'Frost Nova',
+    label: 'Frost Nova',
+    icon: '❄️',
+    category: 'control',
+    description: 'Shatter the ground around you, slowing nearby enemies.',
+    animation: { state: 'attack', duration: 600, holdState: 'idle' },
+    quickbar: { slot: 3, hotkey: '4', group: 'ability' },
+    behaviour: { area: { radius: 2, slowMultiplier: 0.6, durationMs: 5000 } },
+    cooldown: 12,
+    resourceCost: { mana: 20 },
+    tags: ['area', 'crowd-control'],
+  }),
+  createSkillDefinition({
+    id: DEFAULT_SKILL_IDS.ability3,
+    name: 'Stoneguard',
+    label: 'Stoneguard',
+    icon: '🛡️',
+    category: 'defence',
+    description: 'Reinforce yourself with stone, increasing defences temporarily.',
+    animation: { state: 'attack', duration: 400, holdState: 'idle' },
+    quickbar: { slot: 4, hotkey: '5', group: 'ability' },
+    behaviour: { buff: { armourBonus: 12, durationMs: 6000 } },
+    cooldown: 18,
+    resourceCost: { mana: 10 },
+    tags: ['buff'],
+  }),
+  createSkillDefinition({
+    id: DEFAULT_SKILL_IDS.ability4,
+    name: 'Celestial Mend',
+    label: 'Celestial Mend',
+    icon: '✨',
+    category: 'support',
+    description: 'Channel radiant energy to heal an ally or yourself.',
+    animation: { state: 'attack', duration: 520, holdState: 'idle' },
+    quickbar: { slot: 5, hotkey: '6', group: 'support' },
+    behaviour: { heal: { base: 18, scaling: 'intelligence', range: 5 } },
+    cooldown: 20,
+    resourceCost: { mana: 22 },
+    tags: ['support', 'healing'],
+  }),
+];
+
+const SKILL_REGISTRY = new Map(SKILL_DEFINITIONS.map((skill) => [skill.id, skill]));
+
+export const getSkillDefinition = (skillId) => {
+  if (!skillId) {
+    return null;
+  }
+  return SKILL_REGISTRY.get(skillId) || null;
+};
+
+const QUICKBAR_TEMPLATE = [
+  { slotIndex: 0, hotkey: '1', skillId: DEFAULT_SKILL_IDS.primary },
+  { slotIndex: 1, hotkey: '2', skillId: DEFAULT_SKILL_IDS.dash },
+  { slotIndex: 2, hotkey: '3', skillId: DEFAULT_SKILL_IDS.ability1 },
+  { slotIndex: 3, hotkey: '4', skillId: DEFAULT_SKILL_IDS.ability2 },
+  { slotIndex: 4, hotkey: '5', skillId: DEFAULT_SKILL_IDS.ability3 },
+  { slotIndex: 5, hotkey: '6', skillId: DEFAULT_SKILL_IDS.ability4 },
+  { slotIndex: 6, hotkey: '7', skillId: null },
+  { slotIndex: 7, hotkey: '8', skillId: null },
+];
+
+export const createQuickbarSlots = () => QUICKBAR_TEMPLATE.map(
+  (descriptor) => createQuickbarSlot(descriptor, getSkillDefinition),
+);
+
+export const getSkillExecutionProfile = (skillId) => {
+  const skill = getSkillDefinition(skillId);
+  if (!skill) {
+    return null;
+  }
+
+  const animation = skill.animation || {};
+  return {
+    skill,
+    animationState: animation.state || 'attack',
+    duration: animation.duration,
+    holdState: animation.holdState,
+    modifiers: skill.modifiers || {},
+  };
+};
+
+export const listSkills = () => [...SKILL_DEFINITIONS];
+export const listQuickbarTemplate = () => QUICKBAR_TEMPLATE.map((entry) => ({ ...entry }));
+
+export default {
+  listSkills,
+  listQuickbarTemplate,
+  createQuickbarSlots,
+  getSkillDefinition,
+  getSkillExecutionProfile,
+};

--- a/server/shared/skills/schema.js
+++ b/server/shared/skills/schema.js
@@ -1,0 +1,86 @@
+const clone = (value) => {
+  if (value === null || value === undefined) {
+    return value;
+  }
+  if (Array.isArray(value)) {
+    return value.map(clone);
+  }
+  if (typeof value === 'object') {
+    return Object.entries(value).reduce((acc, [key, entry]) => {
+      acc[key] = clone(entry);
+      return acc;
+    }, {});
+  }
+  return value;
+};
+
+export const createSkillDefinition = (definition = {}) => {
+  if (!definition.id || typeof definition.id !== 'string') {
+    throw new Error('Skill definitions require a string `id`.');
+  }
+
+  const activation = definition.activation || 'press';
+  const animation = definition.animation ? {
+    state: definition.animation.state || null,
+    duration: Number.isFinite(definition.animation.duration)
+      ? definition.animation.duration
+      : undefined,
+    holdState: definition.animation.holdState || null,
+  } : null;
+
+  const quickbar = definition.quickbar ? {
+    slot: Number.isFinite(definition.quickbar.slot)
+      ? definition.quickbar.slot
+      : null,
+    hotkey: definition.quickbar.hotkey || null,
+    binding: definition.quickbar.binding || definition.id,
+    sortOrder: Number.isFinite(definition.quickbar.sortOrder)
+      ? definition.quickbar.sortOrder
+      : (Number.isFinite(definition.quickbar.slot) ? definition.quickbar.slot : 0),
+    group: definition.quickbar.group || null,
+  } : null;
+
+  return Object.freeze({
+    id: definition.id,
+    name: definition.name || definition.label || definition.id,
+    label: definition.label || definition.name || definition.id,
+    icon: definition.icon || '',
+    description: definition.description || '',
+    category: definition.category || 'general',
+    activation,
+    cooldown: Number.isFinite(definition.cooldown) ? definition.cooldown : 0,
+    resourceCost: clone(definition.resourceCost || {}),
+    animation,
+    modifiers: clone(definition.modifiers || {}),
+    behaviour: clone(definition.behaviour || {}),
+    tags: Array.isArray(definition.tags) ? [...definition.tags] : [],
+    quickbar,
+  });
+};
+
+export const createQuickbarSlot = (descriptor = {}, resolveSkill) => {
+  const slotIndex = Number.isFinite(descriptor.slotIndex)
+    ? descriptor.slotIndex
+    : 0;
+  const baseId = descriptor.id || `slot-${slotIndex + 1}`;
+  const hotkey = descriptor.hotkey || `${slotIndex + 1}`;
+  const skill = descriptor.skillId && typeof resolveSkill === 'function'
+    ? resolveSkill(descriptor.skillId)
+    : null;
+
+  return {
+    id: baseId,
+    slotIndex,
+    hotkey,
+    label: skill ? skill.label : `Empty Slot ${slotIndex + 1}`,
+    icon: skill ? skill.icon : '',
+    skillId: skill ? skill.id : null,
+    skill,
+    binding: descriptor.binding || (skill && skill.quickbar ? skill.quickbar.binding : null),
+  };
+};
+
+export default {
+  createSkillDefinition,
+  createQuickbarSlot,
+};

--- a/src/components/GameCanvas.vue
+++ b/src/components/GameCanvas.vue
@@ -36,6 +36,7 @@
 import { mapStores } from 'pinia';
 
 import UI from '@shared/ui.js';
+import { getSkillExecutionProfile } from '@shared/skills/index.js';
 import config from '@server/config.js';
 import { useUiStore } from '@/stores/ui.js';
 import ClientUI from '../core/utilities/client-ui.js';
@@ -140,12 +141,15 @@ export default {
         return;
       }
 
-      if (phase === 'end') {
-        this.dispatchSkill(skillId, { phase });
-        return;
-      }
+      const profile = getSkillExecutionProfile(skillId) || {};
+      const options = {
+        animationState: profile.animationState,
+        duration: profile.duration,
+        holdState: profile.holdState,
+        modifiers: profile.modifiers || {},
+      };
 
-      this.dispatchSkill(skillId);
+      this.dispatchSkill(skillId, { ...options, phase });
     },
     getViewportSnapshot() {
       const fallbackViewport = {

--- a/src/components/layout/GameContainer.vue
+++ b/src/components/layout/GameContainer.vue
@@ -19,7 +19,7 @@
           class="game-container__world-shell"
           :style="worldShellStyle"
         >
-          <GameCanvas :game="game" />
+          <GameCanvas ref="canvasRef" :game="game" />
           <GameHUD
             :player-id="playerId"
             :party="party"
@@ -209,6 +209,7 @@ export default {
   setup(props, { emit, expose }) {
     const paneHostRef = ref(null);
     const chatboxRef = ref(null);
+    const canvasRef = ref(null);
     const { game } = toRefs(props);
 
     const playerId = computed(() => (game.value && game.value.player ? game.value.player.uuid : null));
@@ -225,15 +226,31 @@ export default {
       emit('request-remap', slot, index);
     };
 
-    expose({ paneHostRef, chatboxRef });
+    const triggerSkill = (skillId, options = {}) => {
+      if (!skillId) {
+        return false;
+      }
+
+      const canvasComponent = canvasRef.value;
+      if (canvasComponent && typeof canvasComponent.dispatchSkill === 'function') {
+        canvasComponent.dispatchSkill(skillId, options);
+        return true;
+      }
+
+      return false;
+    };
+
+    expose({ paneHostRef, chatboxRef, canvasRef, triggerSkill });
 
     return {
       paneHostRef,
       chatboxRef,
+      canvasRef,
       playerId,
       handleRightClick,
       handleQuickSlot,
       handleQuickbarRemap,
+      triggerSkill,
     };
   },
 };

--- a/src/components/ui/world/PartyPanel.vue
+++ b/src/components/ui/world/PartyPanel.vue
@@ -81,13 +81,13 @@
           v-if="isLeader"
           type="button"
           class="party-panel__button"
-          :disabled="!allReady"
+          :disabled="!allReady || !canStartInstance"
           @click="$emit('start-instance')"
         >
           Start instance
         </button>
         <button
-          v-if="isLeader && party.state === 'instance'"
+          v-if="canReturnToTown"
           type="button"
           class="party-panel__button"
           @click="$emit('return-to-town')"
@@ -189,12 +189,23 @@ export default {
       }
       return this.party.members.length > 0 && this.party.members.every(member => member.ready);
     },
+    canStartInstance() {
+      return Boolean(this.party && this.party.state === 'lobby');
+    },
+    canReturnToTown() {
+      if (!this.party || !this.isLeader) {
+        return false;
+      }
+      return ['instance', 'instance-complete'].includes(this.party.state);
+    },
     loadingLabel() {
       if (!this.loading || !this.loading.state) {
         return 'Loading';
       }
       const mapping = {
         'enter-instance': 'Entering instance...',
+        'distribute-rewards': 'Distributing rewards...',
+        'return-instance': 'Returning to town...',
         idle: 'Idle',
       };
       return mapping[this.loading.state] || 'Loading';

--- a/src/core/player/events/party.js
+++ b/src/core/player/events/party.js
@@ -38,4 +38,8 @@ export default {
 
     await context.handlePartySceneTransition(payload.scene || null, payload.playerState || {}, payload.party || null);
   },
+  'party:instance:complete': (message, context) => {
+    const payload = message && message.data ? message.data : {};
+    safeCall(context, 'handlePartyInstanceComplete', payload);
+  },
 };

--- a/tests/unit/context-menu.spec.js
+++ b/tests/unit/context-menu.spec.js
@@ -7,19 +7,19 @@ import {
   vi,
 } from 'vitest';
 
-const mockUI = {
-  getTileOverMouse: vi.fn(() => null),
-  getContextSubjectColor: vi.fn(() => 'inherit'),
-};
+const mockUI = vi.hoisted(() => ({
+  getTileOverMouse: vi.fn(),
+  getContextSubjectColor: vi.fn(),
+}));
 
 vi.mock('#shared/ui.js', () => ({
   default: mockUI,
 }));
 
-const mockQuery = {
+const mockQuery = vi.hoisted(() => ({
   getItemData: vi.fn(),
-  getForegroundData: vi.fn(() => null),
-};
+  getForegroundData: vi.fn(),
+}));
 
 vi.mock('#server/core/data/query.js', () => ({
   default: mockQuery,
@@ -54,7 +54,7 @@ let player;
 
 beforeEach(() => {
   mockUI.getTileOverMouse.mockReturnValue(null);
-  mockUI.getContextSubjectColor.mockImplementation(() => 'inherit');
+  mockUI.getContextSubjectColor.mockReturnValue('inherit');
   mockQuery.getItemData.mockImplementation(id => createBaseItem(id));
   mockQuery.getForegroundData.mockReturnValue(null);
 

--- a/tests/unit/monster-melee-behaviour.spec.js
+++ b/tests/unit/monster-melee-behaviour.spec.js
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import registerMeleeBehaviour from '../../server/core/entities/monster/behaviours/melee.js';
+import { createWorld } from '../../server/core/entities/ai/ecs-lite.js';
+
+describe('melee behaviour registration', () => {
+  let world;
+  let entity;
+  let monster;
+
+  beforeEach(() => {
+    world = createWorld();
+    entity = world.createEntity('monster-1');
+
+    monster = {
+      id: 'monster-1',
+      x: 0,
+      y: 0,
+      spawn: { x: 0, y: 0 },
+      state: {
+        mode: null,
+        pendingAttack: null,
+        respawnAt: null,
+      },
+      behaviour: {},
+      isAlive: true,
+      respawn: { delayMs: 5_000 },
+      respawnNow: vi.fn(),
+      resolvePendingAttack: vi.fn(() => false),
+      resolveTarget: vi.fn(() => null),
+      tryAttack: vi.fn(() => false),
+      pursue: vi.fn(() => false),
+      returnToSpawn: vi.fn(() => false),
+      patrol: vi.fn(() => true),
+    };
+  });
+
+  it('adds expected components and registers world system', () => {
+    const system = registerMeleeBehaviour({ world, entity, monster });
+
+    expect(system).toBeTypeOf('function');
+    expect(world.systems).toContain(system);
+
+    const behaviourComponent = entity.getComponent('behaviour');
+    const lifecycleComponent = entity.getComponent('lifecycle');
+    const monsterComponent = entity.getComponent('monster');
+
+    expect(behaviourComponent).toEqual({ type: 'melee' });
+    expect(lifecycleComponent).toEqual({ dirty: false });
+    expect(monsterComponent).toEqual({ ref: monster });
+  });
+
+  it('marks lifecycle dirty when patrol updates', () => {
+    registerMeleeBehaviour({ world, entity, monster });
+
+    world.update(16, { now: 1_000 });
+
+    expect(monster.patrol).toHaveBeenCalled();
+    const lifecycleComponent = entity.getComponent('lifecycle');
+    expect(lifecycleComponent.dirty).toBe(true);
+    expect(monster.state.mode).toBe('patrolling');
+  });
+
+  it('resolves pending attacks before continuing behaviour', () => {
+    monster.state.pendingAttack = { resolveAt: 500 };
+    monster.resolvePendingAttack.mockReturnValueOnce(true);
+    monster.patrol.mockReturnValueOnce(false);
+
+    registerMeleeBehaviour({ world, entity, monster });
+
+    world.update(16, { now: 1_000 });
+
+    expect(monster.resolvePendingAttack).toHaveBeenCalledWith(1_000);
+    expect(monster.patrol).toHaveBeenCalled();
+    const lifecycleComponent = entity.getComponent('lifecycle');
+    expect(lifecycleComponent.dirty).toBe(true);
+  });
+
+  it('queues respawn when the monster is dead', () => {
+    monster.isAlive = false;
+
+    registerMeleeBehaviour({ world, entity, monster });
+
+    world.update(16, { now: 10_000 });
+
+    const lifecycleComponent = entity.getComponent('lifecycle');
+    expect(monster.respawnNow).not.toHaveBeenCalled();
+    expect(monster.state.respawnAt).toBe(15_000);
+    expect(lifecycleComponent.dirty).toBe(true);
+  });
+});

--- a/tests/unit/skills-schema.spec.js
+++ b/tests/unit/skills-schema.spec.js
@@ -1,0 +1,92 @@
+import { describe, it, expect } from 'vitest';
+
+import {
+  createSkillDefinition,
+  createQuickbarSlot,
+} from '../../server/shared/skills/schema.js';
+
+describe('skill schema', () => {
+  it('creates an immutable skill definition with cloned data', () => {
+    const base = {
+      id: 'arcane:blast',
+      name: 'Arcane Blast',
+      description: 'Channelled burst of arcane energy.',
+      cooldown: 12,
+      resourceCost: { mana: 24 },
+      modifiers: { damage: { type: 'arcane', amount: 32 } },
+      behaviour: { type: 'projectile', speed: 6 },
+      tags: ['magic', 'burst'],
+      quickbar: { slot: 2, binding: 'skills.arcaneBlast', group: 'offense' },
+    };
+
+    const definition = createSkillDefinition(base);
+
+    expect(Object.isFrozen(definition)).toBe(true);
+    expect(definition.id).toBe('arcane:blast');
+    expect(definition.name).toBe('Arcane Blast');
+    expect(definition.cooldown).toBe(12);
+    expect(definition.resourceCost).not.toBe(base.resourceCost);
+    expect(definition.modifiers).not.toBe(base.modifiers);
+    expect(definition.behaviour).not.toBe(base.behaviour);
+    expect(definition.tags).not.toBe(base.tags);
+    expect(definition.quickbar).not.toBe(base.quickbar);
+    expect(definition.quickbar).toEqual({
+      slot: 2,
+      hotkey: null,
+      binding: 'skills.arcaneBlast',
+      sortOrder: 2,
+      group: 'offense',
+    });
+  });
+
+  it('resolves quickbar slots from skill definitions', () => {
+    const skill = createSkillDefinition({
+      id: 'guard:dash',
+      label: 'Dash',
+      icon: 'dash.png',
+      quickbar: {
+        slot: 0,
+        hotkey: 'Q',
+        binding: 'skills.dash',
+      },
+    });
+
+    const slot = createQuickbarSlot(
+      { slotIndex: 0, hotkey: 'Q', skillId: 'guard:dash' },
+      (skillId) => (skillId === skill.id ? skill : null),
+    );
+
+    expect(slot.id).toBe('slot-1');
+    expect(slot.label).toBe('Dash');
+    expect(slot.icon).toBe('dash.png');
+    expect(slot.hotkey).toBe('Q');
+    expect(slot.skillId).toBe('guard:dash');
+    expect(slot.binding).toBe('skills.dash');
+  });
+
+  it('allows explicit quickbar bindings to override skill defaults', () => {
+    const skill = createSkillDefinition({
+      id: 'guardian:taunt',
+      quickbar: {
+        slot: 3,
+        binding: 'skills.taunt',
+      },
+    });
+
+    const slot = createQuickbarSlot(
+      {
+        id: 'party-slot',
+        slotIndex: 3,
+        hotkey: 'R',
+        skillId: 'guardian:taunt',
+        binding: 'party.callout',
+      },
+      (skillId) => (skillId === skill.id ? skill : null),
+    );
+
+    expect(slot.id).toBe('party-slot');
+    expect(slot.hotkey).toBe('R');
+    expect(slot.binding).toBe('party.callout');
+    expect(slot.label).toBe('guardian:taunt');
+  });
+});

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -1,9 +1,27 @@
+import { createRequire } from 'module';
 import { mergeConfig, defineConfig } from 'vitest/config';
 import viteConfig from './vite.config.js';
 
+const require = createRequire(import.meta.url);
+
+const resolveEnvironment = () => {
+  if (process.env.VITEST_ENV) {
+    return process.env.VITEST_ENV;
+  }
+
+  try {
+    require.resolve('jsdom');
+    return 'jsdom';
+  } catch (error) {
+    return 'node';
+  }
+};
+
 export default mergeConfig(viteConfig, defineConfig({
   test: {
-    environment: 'jsdom',
+    environment: resolveEnvironment(),
+    include: ['tests/unit/**/*.spec.js'],
+    exclude: ['tests/e2e/**'],
     globals: true,
     setupFiles: ['./tests/unit/setup.js'],
     coverage: {


### PR DESCRIPTION
## Summary
- add a shared skill schema with quickbar presets and wire quick slot activation into skill dispatch
- build ECS-lite monster behaviours for melee, ranged, and support roles and seed generated instances with tailored monsters
- extend party and world management to spawn dungeon scenes, distribute rewards, and manage returning to town

## Testing
- npm run lint *(fails: import resolver dependencies for alias paths are unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_69013184019c8321a47df19176158c75