### PR TITLE
Fix build regressions from dependency upgrades

### DIFF
--- a/src/components/passives/FlowerOfLifePane.vue
+++ b/src/components/passives/FlowerOfLifePane.vue
@@ -230,8 +230,9 @@
 </template>
 
 <script>
-import { mapActions } from 'vuex';
+import { mapActions, mapStores } from 'pinia';
 import FlowerOfLifeTree from './FlowerOfLifeTree.vue';
+import { useUiStore } from '@/stores/ui.js';
 import {
   FLOWER_OF_LIFE_LAYOUT,
   FLOWER_OF_LIFE_NODES,
@@ -273,15 +274,12 @@ export default {
     };
   },
   computed: {
+    ...mapStores(useUiStore),
     player() {
       return this.game && this.game.player ? this.game.player : {};
     },
     flowerProgress() {
-      const passives = this.$store && this.$store.state && this.$store.state.passives;
-      if (!passives || !passives.flowerOfLife) {
-        return FLOWER_OF_LIFE_DEFAULT_PROGRESS;
-      }
-      return passives.flowerOfLife;
+      return this.uiStore?.flowerOfLifeState || FLOWER_OF_LIFE_DEFAULT_PROGRESS;
     },
     allocatedSet() {
       return new Set(this.flowerProgress.allocatedNodes || []);
@@ -491,7 +489,7 @@ export default {
     this.clearFeedbackTimeout();
   },
   methods: {
-    ...mapActions([
+    ...mapActions(useUiStore, [
       'allocateFlowerNode',
       'refundFlowerNode',
       'resetFlowerOfLife',

--- a/src/components/slots/Stats.vue
+++ b/src/components/slots/Stats.vue
@@ -68,13 +68,16 @@
 </template>
 
 <script>
-import { ATTRIBUTE_IDS, ATTRIBUTE_LABELS, aggregateAttributes } from '@shared/stats.js';
+import { mapStores } from 'pinia';
+import { ATTRIBUTE_IDS, ATTRIBUTE_LABELS, aggregateAttributes } from '@shared/stats/index.js';
 import {
   computeAvailablePetalCount,
   sumAllocatedCost,
   computeFlowerAttributeBonuses,
+  FLOWER_OF_LIFE_DEFAULT_PROGRESS,
 } from '@shared/passives/flower-of-life.js';
 import bus from '@/core/utilities/bus';
+import { useUiStore } from '@/stores/ui.js';
 
 const normaliseNumber = value => (Number.isFinite(value) ? value : 0);
 const normaliseAttributes = (source = {}) => ATTRIBUTE_IDS.reduce((acc, attributeId) => {
@@ -90,20 +93,12 @@ export default {
     },
   },
   computed: {
+    ...mapStores(useUiStore),
     player() {
       return this.game && this.game.player ? this.game.player : {};
     },
     flowerProgress() {
-      const passives = this.$store && this.$store.state && this.$store.state.passives;
-      if (!passives || !passives.flowerOfLife) {
-        return {
-          allocatedNodes: [],
-          manualMilestones: {},
-          counters: {},
-          bonusPetals: 0,
-        };
-      }
-      return passives.flowerOfLife;
+      return this.uiStore?.flowerOfLifeState || FLOWER_OF_LIFE_DEFAULT_PROGRESS;
     },
     flowerSummary() {
       const summary = computeAvailablePetalCount(this.player, this.flowerProgress);

--- a/src/core/client.js
+++ b/src/core/client.js
@@ -15,7 +15,7 @@ import MovementController from './utilities/movement-controller.js';
 import SpriteAnimator from './utilities/sprite-animator.js';
 import { PLAYER_SPRITE_CONFIG } from './config/animation.js';
 import { DEFAULT_FACING_DIRECTION } from '@shared/combat.js';
-import { createCharacterState, syncShortcuts } from '@shared/stats.js';
+import { createCharacterState, syncShortcuts } from '@shared/stats/index.js';
 import { DEFAULT_MOVE_DURATION_MS, now } from './config/movement.js';
 
 import Map from './map.js';

--- a/src/main.js
+++ b/src/main.js
@@ -1,6 +1,6 @@
 import { createApp } from 'vue';
 import { plugin as VueTippy } from 'vue-tippy';
-import 'vue-tippy/dist/vue-tippy.css';
+import 'tippy.js/dist/tippy.css';
 
 import Delaford from './Delaford.vue';
 import Socket from './core/utilities/socket.js';


### PR DESCRIPTION
## Summary
- fix client tooltip stylesheet import to match vue-tippy v6 dependency layout
- migrate passive tree and stats panes from Vuex helpers to the Pinia UI store
- correct shared stats import path after server module restructuring

## Testing
- npm run build
- npm run test:unit

------
https://chatgpt.com/codex/tasks/task_e_69013c485ec083218d0fd0c84c4aff4a