### PR TITLE
Improve responsive layout and map scaling

### DIFF
--- a/src/assets/scss/abstracts/_breakpoints.scss
+++ b/src/assets/scss/abstracts/_breakpoints.scss
@@ -3,8 +3,8 @@
 
 $breakpoints: (
   'mobile': 0,
-  'tablet': 768px,
-  'desktop': 1200px,
+  'tablet': 640px,
+  'desktop': 1280px,
 );
 
 @function breakpoint-value($name) {

--- a/src/components/hud/Quickbar.vue
+++ b/src/components/hud/Quickbar.vue
@@ -158,7 +158,7 @@ export default {
   letter-spacing: 0.08em;
 }
 
-@media (max-width: 768px) {
+@media (width <= 640px) {
   .quickbar {
     min-width: min(90vw, 520px);
     padding: var(--space-xs) var(--space-sm);

--- a/src/components/layout/GameContainer.vue
+++ b/src/components/layout/GameContainer.vue
@@ -265,7 +265,7 @@ export default {
   justify-content: center;
   align-items: stretch;
   position: relative;
-  padding: clamp(1rem, 3vw, 2.5rem);
+  padding: clamp(1rem, 2.5vw, 3rem);
   width: 100%;
   min-height: 0;
   box-sizing: border-box;
@@ -285,18 +285,21 @@ export default {
   justify-content: flex-start;
   width: 100%;
   position: relative;
+  gap: clamp(var(--space-lg), 3vw, var(--space-2xl));
 }
 
 .game-container__world-shell {
+  --world-shell-padding: clamp(var(--space-lg), 3vw, var(--space-2xl));
+
   position: relative;
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  padding: var(--space-xl);
-  gap: var(--space-lg);
-  width: 100%;
-  max-width: min(1400px, 96vw);
+  padding: var(--world-shell-padding);
+  gap: clamp(var(--space-lg), 2vw, var(--space-xl));
+  width: min(100%, var(--world-display-width, 100%));
+  max-width: min(96vw, var(--world-display-width, 1200px));
   margin: 0 auto;
   border-radius: var(--radius-lg);
   background: rgba(8, 10, 20, 0.65);
@@ -326,6 +329,7 @@ export default {
   transform: translate(-50%, -50%);
   width: var(--world-display-width, 100%);
   height: var(--world-display-height, auto);
+  max-width: 100%;
   border-radius: var(--radius-md);
   outline: none;
 }
@@ -334,14 +338,18 @@ export default {
   position: relative;
   display: flex;
   justify-content: flex-end;
-  width: 100%;
+  width: min(var(--world-display-width, 100%), 100%);
+  margin: clamp(var(--space-lg), 3vw, var(--space-2xl)) auto 0;
+  pointer-events: auto;
 }
 
 .chat-shell--desktop {
   position: absolute;
-  right: var(--space-xl);
-  bottom: var(--space-2xl);
-  width: auto;
+  left: 50%;
+  transform: translateX(-50%);
+  bottom: clamp(var(--space-lg), 4vw, var(--space-2xl));
+  padding: 0 clamp(var(--space-lg), 3vw, var(--space-2xl));
+  width: min(var(--world-display-width, 100%), 100%);
   pointer-events: none;
 }
 
@@ -350,9 +358,9 @@ export default {
 }
 
 .chat-shell__toggle {
-  position: fixed;
-  right: var(--space-md);
-  bottom: var(--space-2xl);
+  position: absolute;
+  right: clamp(var(--space-md), 4vw, var(--space-xl));
+  bottom: clamp(var(--space-lg), 4vw, var(--space-2xl));
   display: inline-flex;
   align-items: center;
   gap: var(--space-sm);
@@ -364,6 +372,10 @@ export default {
   cursor: pointer;
   box-shadow: var(--shadow-soft);
   z-index: 45;
+}
+
+.chat-shell--desktop .chat-shell__toggle {
+  display: none;
 }
 
 .chat-shell--expanded:not(.chat-shell--desktop) .chat-shell__toggle {
@@ -388,13 +400,26 @@ export default {
   text-align: center;
 }
 
-@media (width <= 767px) {
+@media (width <= 639px) {
+  .game-container__center {
+    gap: var(--space-lg);
+  }
+
   .game-container__world-shell {
-    padding: var(--space-md);
+    --world-shell-padding: var(--space-md);
+
+    max-width: 100%;
+  }
+
+  .chat-shell {
+    position: relative;
+    width: 100%;
+    padding-bottom: var(--space-xl);
   }
 
   .chat-shell__toggle {
-    bottom: var(--space-xl);
+    right: var(--space-md);
+    bottom: var(--space-md);
   }
 }
 </style>

--- a/src/components/layout/GameHUD.vue
+++ b/src/components/layout/GameHUD.vue
@@ -117,9 +117,12 @@ export default {
 
 .hud-shell {
   position: absolute;
-  left: var(--space-xl);
-  right: var(--space-xl);
-  bottom: var(--space-xl);
+  left: 50%;
+  transform: translateX(-50%);
+  bottom: clamp(var(--space-lg), 4vw, var(--space-2xl));
+  width: min(var(--world-display-width, 100%), 100%);
+  max-width: min(96vw, var(--world-display-width, 1200px));
+  padding: 0 clamp(var(--space-lg), 3vw, var(--space-2xl));
   display: flex;
   flex-direction: column;
   gap: var(--space-sm);
@@ -131,13 +134,13 @@ export default {
   display: grid;
   grid-template-columns: auto minmax(0, 1fr) auto;
   align-items: flex-end;
-  gap: var(--space-lg);
+  gap: clamp(var(--space-md), 2vw, var(--space-xl));
   pointer-events: auto;
 }
 
 .hud-shell__party {
   margin-bottom: var(--space-sm);
-  max-width: 320px;
+  width: min(100%, 320px);
   pointer-events: auto;
 }
 
@@ -158,9 +161,9 @@ export default {
   transform: translateY(18px);
 }
 
-@media (width <= 1199px) {
+@media (width <= 1279px) {
   .hud-shell__row {
-    gap: var(--space-md);
+    gap: clamp(var(--space-sm), 2vw, var(--space-lg));
   }
 
   .hud-shell__quickbar {
@@ -168,10 +171,13 @@ export default {
   }
 }
 
-@media (width <= 767px) {
+@media (width <= 639px) {
   .hud-shell {
     position: static;
     transform: none;
+    width: 100%;
+    max-width: 100%;
+    padding: 0;
     margin-top: var(--space-lg);
   }
 

--- a/src/components/ui/panes/PaneHost.vue
+++ b/src/components/ui/panes/PaneHost.vue
@@ -172,7 +172,7 @@ export default {
       if (!this.leftPaneComponent) {
         return false;
       }
-      return this.layoutMode === 'desktop';
+      return this.layoutMode !== 'mobile';
     },
     showRightPane() {
       if (!this.rightPaneComponent) {
@@ -203,19 +203,23 @@ export default {
 
 <style lang="scss" scoped>
 @use '@/assets/scss/abstracts/tokens' as *;
-@use '@/assets/scss/abstracts/breakpoints' as *;
 
 .pane-host {
+  --pane-host-side-width: clamp(220px, 22vw, 320px);
+
   position: relative;
   display: grid;
-  grid-template-columns: auto minmax(0, 1fr) auto;
-  gap: var(--space-lg);
+  grid-template-columns: minmax(0, var(--pane-host-side-width)) minmax(0, 1fr) minmax(0, var(--pane-host-side-width));
+  gap: clamp(var(--space-md), 2vw, var(--space-xl));
   width: 100%;
   height: 100%;
   align-items: stretch;
   transition: grid-template-columns 160ms ease-out, gap 160ms ease-out;
 
-  &--tablet,
+  &--tablet {
+    grid-template-columns: minmax(0, var(--pane-host-side-width)) minmax(0, 1fr);
+  }
+
   &--mobile {
     grid-template-columns: minmax(0, 1fr);
   }
@@ -224,7 +228,8 @@ export default {
 .pane-host__side {
   display: flex;
   flex-direction: column;
-  min-width: clamp(240px, 18vw, 320px);
+  min-width: var(--pane-host-side-width);
+  max-width: clamp(240px, 28vw, 360px);
   pointer-events: auto;
 
   &--left {
@@ -262,20 +267,16 @@ export default {
   width: 100%;
 }
 
-@include media('<=tablet') {
-  .pane-host__side {
-    min-width: min(420px, 90vw);
-  }
+.pane-host--tablet .pane-host__side {
+  min-width: clamp(260px, 48vw, 420px);
 }
 
-@include media('<=mobile') {
-  .pane-host__overlay {
-    padding: var(--space-lg) var(--space-md);
-  }
+.pane-host--mobile .pane-host__overlay {
+  padding: var(--space-lg) var(--space-md);
+}
 
-  .pane-host__side {
-    min-width: 100%;
-  }
+.pane-host--mobile .pane-host__side {
+  min-width: 100%;
 }
 
 .pane-slide-enter-active,


### PR DESCRIPTION
## Summary
- align the app-wide breakpoint map and layout mode detection with new mobile and tablet widths
- rework PaneHost, game container, HUD, chat shell, and quickbar styles so side panes collapse sooner and overlays anchor to the scaled canvas
- emit dynamic map dimensions from the engine and use them in Delaford.vue to scale the game canvas responsively

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_690222b4086c83218b663a1b27559f31