### PR TITLE
Use native canvas resolution for rendering

### DIFF
--- a/src/components/GameCanvas.vue
+++ b/src/components/GameCanvas.vue
@@ -19,8 +19,6 @@
       id="game-map"
       tabindex="0"
       class="main-canvas gameMap"
-      height="352"
-      width="512"
       @mouseenter="onGame = true"
       @mouseleave="onGame = false"
       @mousemove="mouseSelection"

--- a/src/core/engine.js
+++ b/src/core/engine.js
@@ -101,18 +101,8 @@ class Engine {
     const { bufferCanvas } = this.game.map;
 
     if (mainCtx && bufferCanvas) {
-      mainCtx.clearRect(0, 0, mainCtx.canvas.width, mainCtx.canvas.height);
-      mainCtx.drawImage(
-        bufferCanvas,
-        0,
-        0,
-        bufferCanvas.width,
-        bufferCanvas.height,
-        0,
-        0,
-        mainCtx.canvas.width,
-        mainCtx.canvas.height,
-      );
+      mainCtx.clearRect(0, 0, bufferCanvas.width, bufferCanvas.height);
+      mainCtx.drawImage(bufferCanvas, 0, 0);
     }
   }
 

--- a/src/core/map.js
+++ b/src/core/map.js
@@ -567,12 +567,10 @@ class Map {
     this.bufferCanvas.width = nativeWidth;
     this.bufferCanvas.height = nativeHeight;
 
-    this.canvas.width = displayWidth;
-    this.canvas.height = displayHeight;
+    this.canvas.width = nativeWidth;
+    this.canvas.height = nativeHeight;
     this.canvas.style.width = `${displayWidth}px`;
     this.canvas.style.height = `${displayHeight}px`;
-    this.canvas.style.maxWidth = `${displayWidth}px`;
-    this.canvas.style.maxHeight = `${displayHeight}px`;
 
     const targetForVariables = shell || container;
     if (targetForVariables) {
@@ -616,8 +614,6 @@ class Map {
     if (this.canvas) {
       this.canvas.style.width = '';
       this.canvas.style.height = '';
-      this.canvas.style.maxWidth = '';
-      this.canvas.style.maxHeight = '';
       const container = this.canvas.parentElement;
       const shell = container && container.parentElement ? container.parentElement : null;
       const target = shell || container;


### PR DESCRIPTION
## Summary
- remove hardcoded width and height attributes from the game canvas element
- size the buffer and display canvases to the native 512x320 viewport while applying scale via CSS
- simplify the engine blit to a 1:1 drawImage so the browser handles display scaling cleanly

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_690543d384248321b6fcb2a7e0fa7855