### PR TITLE
refactor: share ecs factory across controllers

### DIFF
--- a/server/core/entities/ai/ecs-lite.js
+++ b/server/core/entities/ai/ecs-lite.js
@@ -1,73 +1,11 @@
-const createEntity = (id) => ({
-  id,
-  components: new Map(),
-  addComponent(type, data) {
-    this.components.set(type, data);
-    return this;
-  },
-  getComponent(type) {
-    return this.components.get(type);
-  },
-  hasComponent(type) {
-    return this.components.has(type);
-  },
-  removeComponent(type) {
-    this.components.delete(type);
-    return this;
-  },
-});
-
-const createWorld = () => {
-  const entities = new Map();
-  const systems = [];
-  const worldContext = {
-    lastUpdateAt: null,
-  };
-
-  return {
-    entities,
-    systems,
-    context: worldContext,
-    createEntity(id) {
-      const entity = createEntity(id);
-      entities.set(id, entity);
-      return entity;
-    },
-    addEntity(entity) {
-      if (entity && entity.id) {
-        entities.set(entity.id, entity);
-      }
-      return entity;
-    },
-    removeEntity(id) {
-      entities.delete(id);
-    },
-    addSystem(system) {
-      if (typeof system === 'function') {
-        systems.push(system);
-      }
-      return system;
-    },
-    update(delta, context = {}) {
-      systems.forEach((system) => {
-        system(this, delta, context);
-      });
-    },
-    query(...componentTypes) {
-      const required = componentTypes.flat().filter(Boolean);
-      if (!required.length) {
-        return Array.from(entities.values());
-      }
-      return Array.from(entities.values()).filter((entity) => (
-        required.every((type) => entity.hasComponent(type))
-      ));
-    },
-  };
-};
-
-export { createWorld, createEntity };
-
-export default {
+/**
+ * Legacy adapter that re-exports the shared ECS factory for controllers that
+ * still import from the historical entities path.
+ */
+export {
   createWorld,
   createEntity,
-};
+  EXPECTED_COMPONENTS,
+} from '../../systems/ecs/factory.js';
+
+export { default } from '../../systems/ecs/factory.js';

--- a/server/core/entities/monster/ai-controller.js
+++ b/server/core/entities/monster/ai-controller.js
@@ -1,4 +1,4 @@
-import { createWorld } from '../ai/ecs-lite.js';
+import { createWorld } from '../../systems/ecs/factory.js';
 import behaviourRegistry, { resolveBehaviour } from './behaviours/index.js';
 
 const createMonsterAIController = (monster) => {

--- a/server/core/systems/ecs/factory.js
+++ b/server/core/systems/ecs/factory.js
@@ -1,0 +1,99 @@
+const EXPECTED_COMPONENTS = Object.freeze({
+  /**
+   * Tracks positional data, velocity, and pathing state required by movement and navigation systems.
+   */
+  movement: 'Position, velocity, and navigation intent for spatial updates.',
+  /**
+   * Governs spawn/despawn lifecycle, health, and dirty flags that drive replication and cleanup.
+   */
+  lifecycle: 'Spawn/despawn state, health, and dirty flags for world sync.',
+  /**
+   * AI behaviour selector such as behaviour trees or finite state machines.
+   */
+  behaviour: 'Behaviour trees, state machines, or scripts controlling decisions.',
+  /**
+   * Queue of pending actions that systems consume each tick.
+   */
+  actionQueue: 'Ordered actions awaiting execution by gameplay systems.',
+  /**
+   * Networking handles that bind entities to sessions, channels, or replication layers.
+   */
+  networking: 'Handles for broadcasting state changes to connected clients.',
+});
+
+const createEntity = (id) => ({
+  id,
+  components: new Map(),
+  addComponent(type, data) {
+    this.components.set(type, data);
+    return this;
+  },
+  getComponent(type) {
+    return this.components.get(type);
+  },
+  hasComponent(type) {
+    return this.components.has(type);
+  },
+  removeComponent(type) {
+    this.components.delete(type);
+    return this;
+  },
+});
+
+const createWorld = (options = {}) => {
+  const entities = new Map();
+  const systems = [];
+  const worldContext = {
+    lastUpdateAt: null,
+    expectedComponents: EXPECTED_COMPONENTS,
+    ...options.context,
+  };
+
+  return {
+    entities,
+    systems,
+    context: worldContext,
+    createEntity(id) {
+      const entity = createEntity(id);
+      entities.set(id, entity);
+      return entity;
+    },
+    addEntity(entity) {
+      if (entity && entity.id) {
+        entities.set(entity.id, entity);
+      }
+      return entity;
+    },
+    removeEntity(id) {
+      entities.delete(id);
+    },
+    addSystem(system) {
+      if (typeof system === 'function') {
+        systems.push(system);
+      }
+      return system;
+    },
+    update(delta, context = {}) {
+      systems.forEach((system) => {
+        system(this, delta, { ...worldContext, ...context });
+      });
+    },
+    query(...componentTypes) {
+      const required = componentTypes.flat().filter(Boolean);
+      if (!required.length) {
+        return Array.from(entities.values());
+      }
+      return Array.from(entities.values()).filter((entity) => (
+        required.every((type) => entity.hasComponent(type))
+      ));
+    },
+  };
+};
+
+export { createWorld, createEntity, EXPECTED_COMPONENTS };
+
+export default {
+  createWorld,
+  createEntity,
+  EXPECTED_COMPONENTS,
+};


### PR DESCRIPTION
## Summary
- extract the lightweight ECS factory into server/core/systems/ecs for reuse
- document the expected entity components to guide upcoming system wiring
- update monster AI controller while keeping the legacy adapter for existing imports

## Testing
- npm run test:unit -- monster-melee

------
https://chatgpt.com/codex/tasks/task_e_69055b78c5788321974bb978270f070b