### PR TITLE
Add ECS movement/action systems and AI controllers

### DIFF
--- a/server/core/entities/monster/ai-controller.js
+++ b/server/core/entities/monster/ai-controller.js
@@ -1,8 +1,16 @@
-import { createWorld } from '../../systems/ecs/factory.js';
+import { createSceneWorld } from '../../systems/world-factory.js';
 import behaviourRegistry, { resolveBehaviour } from './behaviours/index.js';
 
 const createMonsterAIController = (monster) => {
-  const world = createWorld();
+  const world = createSceneWorld({
+    worldOptions: {
+      context: {
+        actorType: 'monster',
+        sceneId: monster.sceneId || null,
+        controller: 'monster-ai',
+      },
+    },
+  });
   const entity = world.createEntity(monster.uuid);
 
   entity.addComponent('monster', { ref: monster });

--- a/server/core/systems/action-queue-system.js
+++ b/server/core/systems/action-queue-system.js
@@ -1,0 +1,130 @@
+const ensureQueue = (component, key = 'queue') => {
+  if (!component[key] || !Array.isArray(component[key])) {
+    component[key] = [];
+  }
+  return component[key];
+};
+
+const normaliseIntent = (action) => {
+  if (!action) {
+    return null;
+  }
+
+  if (action.intent) {
+    return { ...action.intent };
+  }
+
+  if (Array.isArray(action.intents) && action.intents.length) {
+    return action.intents.map(intent => ({ ...intent }));
+  }
+
+  if (action.type && action.type.startsWith('move:')) {
+    const [, direction] = action.type.split(':');
+    return { type: 'move', direction };
+  }
+
+  return { ...action };
+};
+
+const defaultMovementDispatcher = ({ entity, action }) => {
+  const intentComponent = entity.getComponent('movement-intent');
+  if (!intentComponent) {
+    return false;
+  }
+
+  const queue = ensureQueue(intentComponent);
+  const intent = normaliseIntent(action);
+  if (!intent) {
+    return false;
+  }
+
+  const intents = Array.isArray(intent) ? intent : [intent];
+  intents.filter(Boolean).forEach((entry) => {
+    const payload = { ...entry };
+    if (!payload.type && typeof action.intentType === 'string') {
+      payload.type = action.intentType;
+    }
+    if (!payload.meta && action.meta) {
+      payload.meta = { ...action.meta };
+    }
+    queue.push(payload);
+  });
+
+  return true;
+};
+
+const defaultAIDispatcher = ({ action, entity, world, context }) => {
+  if (typeof action.execute === 'function') {
+    return action.execute({ action, entity, world, context }) !== false;
+  }
+  if (typeof action.run === 'function') {
+    return action.run({ action, entity, world, context }) !== false;
+  }
+  if (typeof action.handler === 'function') {
+    return action.handler({ action, entity, world, context }) !== false;
+  }
+  return false;
+};
+
+const DEFAULT_DISPATCHERS = Object.freeze({
+  move: defaultMovementDispatcher,
+  step: defaultMovementDispatcher,
+  walk: defaultMovementDispatcher,
+  skill: null,
+  ai: defaultAIDispatcher,
+});
+
+const createActionQueueSystem = (options = {}) => {
+  const dispatchers = {
+    ...DEFAULT_DISPATCHERS,
+    ...options.dispatchers,
+  };
+
+  return (world, delta, context = {}) => {
+    const entities = world.query('action-queue');
+    entities.forEach((entity) => {
+      const actionComponent = entity.getComponent('action-queue');
+      if (!actionComponent || actionComponent.suspended) {
+        return;
+      }
+
+      const queue = ensureQueue(actionComponent);
+      if (!queue.length) {
+        actionComponent.active = null;
+        return;
+      }
+
+      const action = queue.shift();
+      const dispatcher = dispatchers[action.type] || dispatchers.default;
+
+      if (!dispatcher) {
+        actionComponent.active = null;
+        return;
+      }
+
+      actionComponent.active = action;
+      const handled = dispatcher({
+        world,
+        delta,
+        context,
+        entity,
+        action,
+      });
+
+      if (handled === 'defer') {
+        actionComponent.active = null;
+        queue.unshift(action);
+        return;
+      }
+
+      if (handled && handled.requeue) {
+        queue.unshift(handled.requeue);
+      }
+
+      actionComponent.active = null;
+      actionComponent.lastProcessedAt = context.now || Date.now();
+    });
+  };
+};
+
+export { createActionQueueSystem as default, createActionQueueSystem };

--- a/server/core/systems/controllers/base-controller.js
+++ b/server/core/systems/controllers/base-controller.js
@@ -1,0 +1,116 @@
+import { createSceneWorld, registerWorldSystems } from '../world-factory.js';
+
+const ensureComponentQueue = (entity, componentName, key = 'queue') => {
+  const component = entity.getComponent(componentName);
+  if (!component) {
+    return null;
+  }
+  if (!Array.isArray(component[key])) {
+    component[key] = [];
+  }
+  return component[key];
+};
+
+const enqueueAction = (entity, action = {}) => {
+  if (!action || typeof action !== 'object') {
+    return null;
+  }
+  const queue = ensureComponentQueue(entity, 'action-queue');
+  if (!queue) {
+    return null;
+  }
+  queue.push({ ...action });
+  return action;
+};
+
+const enqueueMovementIntent = (entity, intent = {}) => {
+  if (!intent || typeof intent !== 'object') {
+    return null;
+  }
+  const movement = entity.getComponent('movement-intent');
+  if (!movement) {
+    return null;
+  }
+  const queue = ensureComponentQueue(entity, 'movement-intent');
+  const payload = { ...intent };
+  if (!payload.type && payload.method) {
+    payload.type = payload.method;
+  }
+  queue.push(payload);
+  return payload;
+};
+
+const dispatchBehaviourScript = ({ entity, world, now, delta }) => {
+  const behaviour = entity.getComponent('behaviour-config');
+  if (!behaviour) {
+    return;
+  }
+
+  const queue = ensureComponentQueue(entity, 'action-queue');
+  if (!queue) {
+    return;
+  }
+
+  if (typeof behaviour.script === 'function') {
+    try {
+      const outcome = behaviour.script({ entity, world, now, delta });
+      const actions = Array.isArray(outcome) ? outcome : (outcome ? [outcome] : []);
+      actions.filter(Boolean).forEach(action => queue.push({ ...action }));
+    } catch (error) {
+      console.error('[controller] behaviour.script failed', error);
+    }
+  }
+
+  if (Array.isArray(behaviour.routine) && behaviour.routine.length > 0) {
+    const state = behaviour.state || (behaviour.state = { index: 0, lastRunAt: 0 });
+    const interval = Number.isFinite(behaviour.intervalMs) ? behaviour.intervalMs : 0;
+    if (!state.lastRunAt || now - state.lastRunAt >= interval) {
+      const step = behaviour.routine[state.index % behaviour.routine.length];
+      if (step) {
+        queue.push({ ...step });
+      }
+      state.index = (state.index + 1) % behaviour.routine.length;
+      state.lastRunAt = now;
+    }
+  }
+};
+
+const buildControllerEntity = ({
+  world,
+  id,
+  transform,
+  movementState,
+  movementIntent,
+  actionQueue,
+  behaviour,
+}) => {
+  const entity = world.createEntity(id);
+  entity.addComponent('transform', transform || {});
+  entity.addComponent('movement-state', movementState || {});
+  entity.addComponent('movement-intent', movementIntent || { queue: [] });
+  entity.addComponent('action-queue', actionQueue || { queue: [] });
+  if (behaviour) {
+    entity.addComponent('behaviour-config', behaviour);
+  }
+  world.addEntity(entity);
+  return entity;
+};
+
+const createControllerWorld = (options = {}) => {
+  if (options.world) {
+    registerWorldSystems(options.world, options.systemOptions);
+    return options.world;
+  }
+  const world = createSceneWorld(options.worldOptions || {});
+  registerWorldSystems(world, options.systemOptions);
+  return world;
+};
+
+export {
+  ensureComponentQueue,
+  enqueueAction,
+  enqueueMovementIntent,
+  dispatchBehaviourScript,
+  buildControllerEntity,
+  createControllerWorld,
+};

--- a/server/core/systems/controllers/npc-ai-controller.js
+++ b/server/core/systems/controllers/npc-ai-controller.js
@@ -1,0 +1,108 @@
+import {
+  buildControllerEntity,
+  createControllerWorld,
+  dispatchBehaviourScript,
+  enqueueAction,
+} from './base-controller.js';
+
+const DEFAULT_RANDOM_MOVE_INTERVAL = 4_000;
+
+const enqueueRandomMovement = (entity, worldRef) => {
+  enqueueAction(entity, {
+    type: 'move',
+    intent: {
+      type: 'method',
+      method: 'performRandomMovement',
+      args: [worldRef],
+    },
+    meta: { source: 'npc-random' },
+  });
+};
+
+const ensureRandomMovementSchedule = ({ entity, now, behaviour, worldRef }) => {
+  if (!behaviour || behaviour.type === 'random-walk' || !behaviour.type) {
+    const state = behaviour && (behaviour.state || (behaviour.state = {}));
+    const interval = behaviour && Number.isFinite(behaviour.intervalMs)
+      ? behaviour.intervalMs
+      : DEFAULT_RANDOM_MOVE_INTERVAL;
+    if (!state || !state.lastRandomMove || now - state.lastRandomMove >= interval) {
+      enqueueRandomMovement(entity, worldRef);
+      if (state) {
+        state.lastRandomMove = now;
+      }
+    }
+  }
+};
+
+const createNPCAIController = (npc, options = {}) => {
+  if (!npc) {
+    throw new Error('NPC reference is required for NPCAIController');
+  }
+
+  const world = createControllerWorld({
+    world: options.world,
+    worldOptions: {
+      context: {
+        actorType: 'npc',
+        sceneId: npc.sceneId || options.sceneId || null,
+        controller: 'npc-ai',
+      },
+    },
+    systemOptions: options.systemOptions || {},
+  });
+
+  const entityId = options.entityId || npc.uuid || npc.id || `npc:${Date.now()}`;
+  const entity = buildControllerEntity({
+    world,
+    id: entityId,
+    transform: {
+      ref: npc,
+      sceneId: npc.sceneId || options.sceneId || null,
+      x: npc.x || 0,
+      y: npc.y || 0,
+      facing: npc.facing || null,
+      animation: npc.animation || null,
+    },
+    movementState: {
+      handler: npc.movement,
+      actor: npc,
+    },
+    movementIntent: { queue: [] },
+    actionQueue: { queue: [] },
+    behaviour: options.behaviour || {
+      type: 'random-walk',
+      intervalMs: options.intervalMs || DEFAULT_RANDOM_MOVE_INTERVAL,
+    },
+  });
+
+  const behaviourComponent = entity.getComponent('behaviour-config');
+  if (behaviourComponent && !behaviourComponent.type) {
+    behaviourComponent.type = 'random-walk';
+  }
+
+  let lastUpdateAt = null;
+
+  const controller = {
+    world,
+    entity,
+    enqueueAction: action => enqueueAction(entity, action),
+    update(now = Date.now(), context = {}) {
+      const delta = lastUpdateAt === null ? 0 : now - lastUpdateAt;
+      lastUpdateAt = now;
+      const behaviour = entity.getComponent('behaviour-config');
+      const worldRef = context.worldRef || options.worldRef || null;
+      ensureRandomMovementSchedule({ entity, now, behaviour, worldRef });
+      dispatchBehaviourScript({ entity, world, now, delta });
+      world.update(delta, { ...context, now, actor: npc });
+    },
+    destroy() {
+      if (world && typeof world.removeEntity === 'function') {
+        world.removeEntity(entity.id);
+      }
+    },
+  };
+
+  return controller;
+};
+
+export default createNPCAIController;

--- a/server/core/systems/controllers/player-ai-controller.js
+++ b/server/core/systems/controllers/player-ai-controller.js
@@ -1,0 +1,120 @@
+import {
+  buildControllerEntity,
+  createControllerWorld,
+  dispatchBehaviourScript,
+  enqueueAction,
+} from './base-controller.js';
+
+const normaliseMovementIntent = (direction, meta = {}) => {
+  if (direction && typeof direction === 'object') {
+    return { ...direction };
+  }
+  return {
+    type: meta.type || 'move',
+    direction,
+    options: meta.options || {},
+    method: meta.method,
+    args: meta.args,
+    data: meta.data,
+    meta: meta.meta,
+  };
+};
+
+const enqueueMovementAction = (entity, direction, meta = {}) => {
+  const intent = normaliseMovementIntent(direction, meta);
+  enqueueAction(entity, {
+    type: 'move',
+    intent,
+    meta: meta.meta || intent.meta || {},
+    intentType: intent.type,
+  });
+  return intent;
+};
+
+const enqueuePathAction = (entity, path, meta = {}) => {
+  const args = meta.args || [];
+  if (!Array.isArray(args) || !args.length) {
+    args.push(meta.playerIndex ?? null);
+    if (path !== undefined) {
+      args.push(path);
+    }
+  }
+  const intent = {
+    type: 'walk-path',
+    method: 'walkPath',
+    args,
+    meta: meta.meta || {},
+  };
+  enqueueAction(entity, {
+    type: 'move',
+    intent,
+    intentType: 'walk-path',
+    meta: intent.meta,
+  });
+  return intent;
+};
+
+const createPlayerAIController = (player, options = {}) => {
+  if (!player) {
+    throw new Error('Player reference is required for PlayerAIController');
+  }
+
+  const world = createControllerWorld({
+    world: options.world,
+    worldOptions: {
+      context: {
+        actorType: 'player',
+        sceneId: player.sceneId || null,
+        controller: 'player-ai',
+      },
+    },
+    systemOptions: options.systemOptions || {},
+  });
+
+  const entityId = options.entityId || player.uuid || player.id || `player:${Date.now()}`;
+  const entity = buildControllerEntity({
+    world,
+    id: entityId,
+    transform: {
+      ref: player,
+      sceneId: player.sceneId || null,
+      x: player.x || 0,
+      y: player.y || 0,
+      facing: player.facing || null,
+      animation: player.animation || null,
+    },
+    movementState: {
+      handler: player.movement,
+      actor: player,
+      playerIndex: options.playerIndex ?? null,
+    },
+    movementIntent: { queue: [] },
+    actionQueue: { queue: [] },
+    behaviour: options.behaviour || player.behaviour || null,
+  });
+
+  let lastUpdateAt = null;
+
+  const controller = {
+    world,
+    entity,
+    enqueueAction: action => enqueueAction(entity, action),
+    enqueueMovement: (direction, meta) => enqueueMovementAction(entity, direction, meta),
+    enqueuePath: (path, meta) => enqueuePathAction(entity, path, meta),
+    update(now = Date.now(), context = {}) {
+      const delta = lastUpdateAt === null ? 0 : now - lastUpdateAt;
+      lastUpdateAt = now;
+      dispatchBehaviourScript({ entity, world, now, delta });
+      world.update(delta, { ...context, now, actor: player });
+    },
+    destroy() {
+      if (world && typeof world.removeEntity === 'function') {
+        world.removeEntity(entity.id);
+      }
+    },
+  };
+
+  return controller;
+};
+
+export default createPlayerAIController;

--- a/server/core/systems/movement-system.js
+++ b/server/core/systems/movement-system.js
@@ -1,0 +1,180 @@
+const MOVEMENT_COMPONENTS = ['transform', 'movement-state', 'movement-intent'];
+
+const toArray = (value) => (Array.isArray(value) ? value : (value ? [value] : []));
+
+const ensureQueue = (component, key = 'queue') => {
+  if (!component[key] || !Array.isArray(component[key])) {
+    component[key] = [];
+  }
+  return component[key];
+};
+
+const defaultMethodForType = (type) => {
+  switch (type) {
+    case 'step':
+      return 'step';
+    case 'move':
+    case 'walk':
+      return 'move';
+    case 'path':
+    case 'walk-path':
+      return 'walkPath';
+    case 'stop':
+    case 'halt':
+      return 'stopMovement';
+    case 'cancel-path':
+      return 'cancelPathfinding';
+    default:
+      return null;
+  }
+};
+
+const synchroniseTransform = (transform, movementState) => {
+  if (!transform || !transform.ref) {
+    return;
+  }
+
+  const actor = transform.ref;
+  transform.sceneId = actor.sceneId ?? transform.sceneId ?? null;
+  transform.x = actor.x ?? transform.x ?? 0;
+  transform.y = actor.y ?? transform.y ?? 0;
+  transform.facing = actor.facing ?? transform.facing ?? null;
+  transform.animation = actor.animation ?? transform.animation ?? null;
+  transform.movementStep = actor.movementStep ?? transform.movementStep ?? null;
+
+  if (movementState) {
+    movementState.blocked = Boolean(actor.movementStep && actor.movementStep.blocked);
+  }
+};
+
+const invokeHandler = ({ handler, intent, context, movementState }) => {
+  if (!handler || !intent) {
+    return { consumed: true, result: null };
+  }
+
+  const method = intent.method
+    || defaultMethodForType(intent.type)
+    || (typeof intent.type === 'string' && handler[intent.type] ? intent.type : null);
+
+  if (!method || typeof handler[method] !== 'function') {
+    return { consumed: true, result: null };
+  }
+
+  let args = [];
+  if (Array.isArray(intent.args)) {
+    args = intent.args;
+  } else {
+    switch (method) {
+      case 'step':
+        args = [intent.direction, context.now];
+        break;
+      case 'move':
+        args = [intent.direction, intent.options || intent.meta || {}];
+        break;
+      case 'walkPath':
+        if (intent.args && Array.isArray(intent.args)) {
+          args = intent.args;
+        } else {
+          args = [intent.playerIndex ?? movementState?.playerIndex ?? 0];
+        }
+        break;
+      case 'stopMovement':
+        args = [intent.data || intent.meta || {}];
+        break;
+      case 'cancelPathfinding':
+        args = [];
+        break;
+      default:
+        args = intent.args ? toArray(intent.args) : [];
+        break;
+    }
+  }
+
+  const result = handler[method](...args);
+
+  if (typeof intent.after === 'function') {
+    try {
+      intent.after({ result, intent, handler, context, movementState });
+    } catch (error) {
+      console.error('[movement-system] intent.after failed', error);
+    }
+  }
+
+  const consumed = intent.persist ? result !== false : intent.consumeOnFalse !== false || result !== false;
+
+  return { consumed, result };
+};
+
+const processEntityMovement = (entity, world, delta, context) => {
+  const transform = entity.getComponent('transform');
+  const movementState = entity.getComponent('movement-state');
+  const intentComponent = entity.getComponent('movement-intent');
+
+  if (!transform || !movementState || !intentComponent) {
+    return;
+  }
+
+  const queue = ensureQueue(intentComponent);
+  if (!intentComponent.current && queue.length) {
+    intentComponent.current = queue.shift();
+  }
+
+  const intent = intentComponent.current;
+  if (!intent) {
+    synchroniseTransform(transform, movementState);
+    return;
+  }
+
+  const handler = movementState.handler
+    || transform.ref?.movement
+    || movementState.controller
+    || null;
+
+  const { consumed } = invokeHandler({
+    handler,
+    intent,
+    context,
+    movementState,
+  });
+
+  movementState.lastIntentAt = context.now;
+  movementState.lastIntentType = intent.type || intent.method || null;
+
+  synchroniseTransform(transform, movementState);
+
+  if (!consumed) {
+    if (intent.requeueOnFail) {
+      queue.unshift(intent);
+      intentComponent.current = null;
+    }
+    return;
+  }
+
+  if (typeof intent.onComplete === 'function') {
+    try {
+      intent.onComplete({ entity, world, intent, context, movementState });
+    } catch (error) {
+      console.error('[movement-system] intent.onComplete failed', error);
+    }
+  }
+
+  intentComponent.last = intent;
+  intentComponent.current = null;
+};
+
+const createMovementSystem = (options = {}) => {
+  const systemContext = {
+    id: options.id || 'movement-system',
+  };
+
+  return (world, delta, context = {}) => {
+    const now = Number.isFinite(context.now) ? context.now : Date.now();
+    const runtimeContext = { ...context, now, system: systemContext };
+    const entities = world.query(MOVEMENT_COMPONENTS);
+    entities.forEach((entity) => {
+      processEntityMovement(entity, world, delta, runtimeContext);
+    });
+  };
+};
+
+export { createMovementSystem as default, createMovementSystem, MOVEMENT_COMPONENTS };

--- a/server/core/systems/world-factory.js
+++ b/server/core/systems/world-factory.js
@@ -1,0 +1,84 @@
+import { createWorld } from './ecs/factory.js';
+import createActionQueueSystem from './action-queue-system.js';
+import createMovementSystem from './movement-system.js';
+
+const ensureRegistry = (world) => {
+  if (!world.context) {
+    world.context = {};
+  }
+  if (!world.context.__systemRegistry) {
+    world.context.__systemRegistry = new Map();
+  } else if (!(world.context.__systemRegistry instanceof Map)) {
+    const entries = Array.isArray(world.context.__systemRegistry)
+      ? world.context.__systemRegistry
+      : [];
+    world.context.__systemRegistry = new Map(entries);
+  }
+  return world.context.__systemRegistry;
+};
+
+const registerWorldSystems = (world, options = {}) => {
+  if (!world || typeof world.addSystem !== 'function') {
+    return world;
+  }
+
+  const registry = ensureRegistry(world);
+
+  if (!options.skipActionQueue && !registry.has('action-queue')) {
+    const system = options.actionQueueSystem
+      || createActionQueueSystem(options.actionQueueOptions || {});
+    world.addSystem(system);
+    registry.set('action-queue', system);
+  }
+
+  if (!options.skipMovement && !registry.has('movement')) {
+    const system = options.movementSystem
+      || createMovementSystem(options.movementOptions || {});
+    world.addSystem(system);
+    registry.set('movement', system);
+  }
+
+  const extraSystems = options.additionalSystems || options.systems || [];
+  if (Array.isArray(extraSystems)) {
+    extraSystems.forEach((entry) => {
+      if (!entry) {
+        return;
+      }
+      if (typeof entry === 'function') {
+        if (!registry.has(entry)) {
+          world.addSystem(entry);
+          registry.set(entry, entry);
+        }
+        return;
+      }
+      const key = entry.key || entry.id;
+      const { system } = entry;
+      if (typeof system !== 'function') {
+        return;
+      }
+      if (key && registry.has(key)) {
+        return;
+      }
+      world.addSystem(system);
+      if (key) {
+        registry.set(key, system);
+      } else {
+        registry.set(system, system);
+      }
+    });
+  }
+
+  return world;
+};
+
+const createSceneWorld = (options = {}) => {
+  const world = createWorld(options.worldOptions || options);
+  if (options.autoRegister !== false) {
+    registerWorldSystems(world, options.systemOptions || options);
+  }
+  return world;
+};
+
+export { createSceneWorld, registerWorldSystems };
+
+export default createSceneWorld;


### PR DESCRIPTION
## Summary
- add a movement system that delegates queued intents to existing handlers while syncing transform state
- introduce an action queue system and world bootstrap helper to register shared systems for controller worlds
- provide player and NPC AI controllers that enqueue behaviour-driven actions and integrate monsters with the shared setup

## Testing
- npm run test:unit

------
https://chatgpt.com/codex/tasks/task_e_69055db3569c83219bdedf4b551c08a2