### PR TITLE
Integrate player and NPC entities with ECS world

### DIFF
--- a/server/core/npc.js
+++ b/server/core/npc.js
@@ -1,13 +1,46 @@
 import Socket from '#server/socket.js';
 import * as emoji from 'node-emoji';
+import createNPCAIController from '#server/core/systems/controllers/npc-ai-controller.js';
 import createNpcMovementHandler from '#server/core/entities/npc/movement-handler.js';
 import npcs from './data/npcs.js';
 import world from './world.js';
+
+const buildNpcComponents = (npc) => ({
+  identity: {
+    id: npc.id,
+    uuid: npc.uuid || npc.id,
+    type: 'npc',
+    name: npc.name,
+  },
+  transform: {
+    ref: npc,
+    sceneId: npc.sceneId || world.defaultTownId,
+    x: npc.x || 0,
+    y: npc.y || 0,
+    facing: npc.facing || null,
+    animation: npc.animation || null,
+  },
+  'movement-state': {
+    handler: npc.movement,
+    actor: npc,
+  },
+  'movement-intent': {
+    queue: [],
+  },
+  'action-queue': {
+    queue: [],
+  },
+  lifecycle: {
+    state: 'active',
+    dirty: true,
+  },
+});
 
 class NPC {
   constructor(data) {
     this.movement = createNpcMovementHandler(this);
     this.id = data.id;
+    this.uuid = data.uuid || data.id;
     this.name = data.name;
 
     // Examine text
@@ -45,6 +78,34 @@ class NPC {
 
     this.facing = this.movement.resolveFacing(null);
     this.animation = this.createInitialAnimation();
+
+    this.sceneId = data.sceneId || world.defaultTownId;
+
+    this.__ecsComponents = buildNpcComponents(this);
+    const ecsRecord = world.registerActorEntity(this, {
+      sceneId: this.sceneId,
+      components: this.__ecsComponents,
+    });
+    this.ecs = ecsRecord || null;
+    const ecsWorld = ecsRecord ? ecsRecord.world : world.getSceneWorld(this.sceneId);
+    this.controller = createNPCAIController(this, {
+      world: ecsWorld,
+      worldRef: world,
+    });
+    if (this.controller) {
+      const controllerId = this.uuid || this.id;
+      const originalDestroy = typeof this.controller.destroy === 'function'
+        ? this.controller.destroy.bind(this.controller)
+        : null;
+      this.controller.destroy = (...args) => {
+        NPC.controllers.delete(controllerId);
+        if (originalDestroy) {
+          return originalDestroy(...args);
+        }
+        return undefined;
+      };
+      NPC.controllers.set(controllerId, this.controller);
+    }
   }
 
   resolveFacing(direction, fallback) {
@@ -80,8 +141,16 @@ class NPC {
    * Simulate NPC movement every cycle
    */
   static movement() {
-    world.npcs.forEach((npc) => {
-      npc.movement.performRandomMovement(world);
+    const now = Date.now();
+    NPC.controllers.forEach((controller, id) => {
+      if (!controller || typeof controller.update !== 'function') {
+        return;
+      }
+      try {
+        controller.update(now, { worldRef: world });
+      } catch (error) {
+        console.error(`[npc] controller update failed for ${id}`, error);
+      }
     });
 
     const meta = {
@@ -103,3 +172,5 @@ class NPC {
 }
 
 export default NPC;
+
+NPC.controllers = new Map();


### PR DESCRIPTION
## Summary
- register player and NPC actors with the ECS world and expose networking/persistence components
- add scene world management utilities on the server and enqueue player socket intents through ECS controllers
- run NPC ticks through their AI controllers and clean up ECS registrations when entities despawn

## Testing
- npm run lint -- --max-warnings=0

------
https://chatgpt.com/codex/tasks/task_e_6905654b136c8321893afbd08bfc2aa2