### PR TITLE
Add server-side unit and integration tests

### DIFF
--- a/tests/server/integration/scene-tick.spec.js
+++ b/tests/server/integration/scene-tick.spec.js
@@ -1,0 +1,138 @@
+import { socketBroadcastMock } from '../mocks/socket.js';
+import { axiosPostMock } from '../mocks/axios.js';
+import { describe, it, beforeEach, expect, vi } from 'vitest';
+import createSceneWorld from '#server/core/systems/world-factory.js';
+import Socket from '#server/socket.js';
+import axios from 'axios';
+
+describe('scene tick integration', () => {
+  beforeEach(() => {
+    socketBroadcastMock.mockClear();
+    axiosPostMock.mockClear();
+  });
+
+  it('applies movement, combat, and persistence effects across entity types', () => {
+    const world = createSceneWorld({ worldOptions: { context: { sceneId: 'integration-test' } } });
+    const combatLog = [];
+
+    const playerTransform = { x: 0, y: 0, facing: 'south' };
+    const playerMovement = {
+      move: vi.fn(() => {
+        playerTransform.x += 1;
+        return true;
+      }),
+    };
+
+    const playerEntity = world.createEntity('player:1');
+    playerEntity.addComponent('transform', playerTransform);
+    playerEntity.addComponent('movement-state', { handler: playerMovement });
+    playerEntity.addComponent('movement-intent', { queue: [] });
+    playerEntity.addComponent('action-queue', {
+      queue: [
+        {
+          type: 'move',
+          intent: { type: 'move', direction: 'east' },
+        },
+      ],
+    });
+    playerEntity.addComponent('identity', { type: 'player', id: 'player:1', uuid: 'player:1' });
+    playerEntity.addComponent('networking', { broadcast: Socket.broadcast, broadcastKey: 'player:1' });
+    playerEntity.addComponent('lifecycle', { dirty: true });
+    playerEntity.addComponent('persistence', {
+      dirty: true,
+      cooldownMs: 0,
+      save: ({ entity }) => axios.post('/players', {
+        id: entity.getComponent('identity').id,
+        position: { x: playerTransform.x, y: playerTransform.y },
+      }),
+    });
+    world.addEntity(playerEntity);
+
+    const npcTransform = { x: 2, y: 2, facing: 'north' };
+    const npcMovement = {
+      move: vi.fn(() => {
+        npcTransform.y -= 1;
+        return true;
+      }),
+    };
+
+    const npcEntity = world.createEntity('npc:1');
+    npcEntity.addComponent('transform', npcTransform);
+    npcEntity.addComponent('movement-state', { handler: npcMovement });
+    npcEntity.addComponent('movement-intent', { queue: [] });
+    npcEntity.addComponent('action-queue', {
+      queue: [
+        {
+          type: 'move',
+          intent: { type: 'move', direction: 'south' },
+        },
+      ],
+    });
+    npcEntity.addComponent('identity', { type: 'npc', id: 'npc:1', uuid: 'npc:1' });
+    npcEntity.addComponent('networking', { broadcast: Socket.broadcast, broadcastKey: 'npc:1' });
+    world.addEntity(npcEntity);
+
+    const monsterTransform = { x: -1, y: 0, facing: 'west' };
+    const monsterMovement = {
+      move: vi.fn(() => {
+        monsterTransform.x -= 1;
+        return true;
+      }),
+    };
+
+    const monsterEntity = world.createEntity('monster:1');
+    monsterEntity.addComponent('transform', monsterTransform);
+    monsterEntity.addComponent('movement-state', { handler: monsterMovement });
+    monsterEntity.addComponent('movement-intent', { queue: [] });
+    monsterEntity.addComponent('action-queue', {
+      queue: [
+        {
+          type: 'move',
+          intent: { type: 'move', direction: 'west' },
+        },
+        {
+          type: 'ai',
+          execute: ({ entity }) => {
+            combatLog.push({ entity: entity.id, target: 'player:1', damage: 5 });
+            const lifecycle = entity.getComponent('lifecycle');
+            if (lifecycle) {
+              lifecycle.dirty = true;
+            }
+            return true;
+          },
+        },
+      ],
+    });
+    monsterEntity.addComponent('identity', { type: 'monster', id: 'monster:1', uuid: 'monster:1' });
+    monsterEntity.addComponent('networking', { broadcast: Socket.broadcast, broadcastKey: 'monster:1' });
+    monsterEntity.addComponent('lifecycle', { dirty: false });
+    world.addEntity(monsterEntity);
+
+    world.update(16, { now: 1_000 });
+    world.update(16, { now: 1_016 });
+
+    expect(playerMovement.move).toHaveBeenCalledWith('east', {});
+    expect(playerTransform.x).toBe(1);
+    expect(npcMovement.move).toHaveBeenCalledWith('south', {});
+    expect(npcTransform.y).toBe(1);
+    expect(monsterMovement.move).toHaveBeenCalledWith('west', {});
+    expect(monsterTransform.x).toBe(-2);
+
+    expect(combatLog).toContainEqual({ entity: 'monster:1', target: 'player:1', damage: 5 });
+
+    const events = socketBroadcastMock.mock.calls.map(call => call[0]);
+    expect(events).toContain('player:movement');
+    expect(events).toContain('npc:movement');
+    expect(events).toContain('monster:movement');
+
+    expect(axiosPostMock).toHaveBeenCalledWith('/players', {
+      id: 'player:1',
+      position: { x: 1, y: 0 },
+    });
+    expect(axiosPostMock).toHaveBeenCalledTimes(1);
+
+    const persistence = playerEntity.getComponent('persistence');
+    expect(persistence.dirty).toBe(false);
+    expect(playerEntity.getComponent('lifecycle').dirty).toBe(false);
+  });
+});

--- a/tests/server/mocks/axios.js
+++ b/tests/server/mocks/axios.js
@@ -1,0 +1,10 @@
+import { vi } from 'vitest';
+
+export const axiosPostMock = vi.fn(() => Promise.resolve({ data: {} }));
+
+vi.mock('axios', () => ({
+  default: {
+    post: axiosPostMock,
+  },
+  post: axiosPostMock,
+}));

--- a/tests/server/mocks/socket.js
+++ b/tests/server/mocks/socket.js
@@ -1,0 +1,9 @@
+import { vi } from 'vitest';
+
+export const socketBroadcastMock = vi.fn();
+
+vi.mock('#server/socket.js', () => ({
+  default: {
+    broadcast: socketBroadcastMock,
+  },
+}));

--- a/tests/server/unit/action-queue-system.spec.js
+++ b/tests/server/unit/action-queue-system.spec.js
@@ -1,0 +1,80 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import createActionQueueSystem from '#server/core/systems/action-queue-system.js';
+import { createWorld } from '#server/core/systems/ecs/factory.js';
+
+const buildEntity = (world, id, type) => {
+  const entity = world.createEntity(id);
+  entity.addComponent('identity', { type, id, uuid: `${id}:uuid` });
+  entity.addComponent('movement-intent', { queue: [] });
+  entity.addComponent('action-queue', { queue: [] });
+  world.addEntity(entity);
+  return entity;
+};
+
+describe('action queue system', () => {
+  let world;
+  let actionQueueSystem;
+
+  beforeEach(() => {
+    world = createWorld();
+    actionQueueSystem = createActionQueueSystem();
+  });
+
+  it.each([
+    ['player'],
+    ['npc'],
+    ['monster'],
+  ])('dispatches movement actions for %s entities', (type) => {
+    const entity = buildEntity(world, `${type}:queue`, type);
+    const actionComponent = entity.getComponent('action-queue');
+    actionComponent.queue.push({
+      type: 'move',
+      intent: { type: 'move', direction: 'west', meta: { reason: 'test' } },
+      meta: { reason: 'test' },
+    });
+
+    actionQueueSystem(world, 16, { now: 10_000 });
+
+    const movementIntent = entity.getComponent('movement-intent');
+    expect(movementIntent.queue).toHaveLength(1);
+    expect(movementIntent.queue[0]).toMatchObject({ type: 'move', direction: 'west', meta: { reason: 'test' } });
+
+    expect(actionComponent.queue).toHaveLength(0);
+    expect(actionComponent.active).toBeNull();
+    expect(actionComponent.lastProcessedAt).toBe(10_000);
+  });
+
+  it('executes AI actions and clears active state', () => {
+    const entity = buildEntity(world, 'monster:ai', 'monster');
+    const execute = vi.fn(() => true);
+    entity.getComponent('action-queue').queue.push({ type: 'ai', execute });
+
+    actionQueueSystem(world, 33, { now: 20_000, actor: { id: 'monster:ai' } });
+
+    expect(execute).toHaveBeenCalledWith({
+      action: expect.objectContaining({ type: 'ai' }),
+      entity,
+      world,
+      context: expect.objectContaining({ now: 20_000 }),
+    });
+    expect(entity.getComponent('action-queue').active).toBeNull();
+  });
+
+  it('requeues deferred actions when dispatcher returns "defer"', () => {
+    const entity = buildEntity(world, 'npc:defer', 'npc');
+    const deferredAction = { type: 'move', intent: { type: 'move', direction: 'north' } };
+    entity.getComponent('action-queue').queue.push(deferredAction);
+
+    const customSystem = createActionQueueSystem({
+      dispatchers: {
+        move: () => 'defer',
+      },
+    });
+
+    customSystem(world, 16, { now: 30_000 });
+
+    const actionComponent = entity.getComponent('action-queue');
+    expect(actionComponent.active).toBeNull();
+    expect(actionComponent.queue[0]).toBe(deferredAction);
+  });
+});

--- a/tests/server/unit/ai-controllers.spec.js
+++ b/tests/server/unit/ai-controllers.spec.js
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi } from 'vitest';
+import createPlayerAIController from '#server/core/systems/controllers/player-ai-controller.js';
+import createNPCAIController from '#server/core/systems/controllers/npc-ai-controller.js';
+import createMonsterAIController from '#server/core/entities/monster/ai-controller.js';
+
+const buildBehaviourScript = (direction) => () => ({
+  type: 'move',
+  intent: { type: 'move', direction },
+});
+
+describe('AI controllers', () => {
+  it('processes scripted movement for players and allows manual intents', () => {
+    const movement = {
+      move: vi.fn(() => true),
+    };
+    const player = {
+      uuid: 'player-1',
+      id: 'player-1',
+      sceneId: 'scene-player',
+      x: 0,
+      y: 0,
+      facing: 'south',
+      animation: null,
+      movement,
+      behaviour: { script: buildBehaviourScript('east') },
+    };
+
+    const controller = createPlayerAIController(player);
+    controller.update(1_000);
+
+    expect(movement.move).toHaveBeenNthCalledWith(1, 'east', {});
+
+    controller.enqueueMovement('north');
+    controller.update(2_000);
+
+    expect(movement.move).toHaveBeenNthCalledWith(2, 'north', {});
+  });
+
+  it('schedules random movement for NPCs and respects behaviour overrides', () => {
+    const movement = {
+      performRandomMovement: vi.fn(() => true),
+    };
+
+    const npc = {
+      uuid: 'npc-1',
+      id: 'npc-1',
+      sceneId: 'scene-npc',
+      x: 0,
+      y: 0,
+      facing: 'north',
+      animation: null,
+      movement,
+    };
+
+    const controller = createNPCAIController(npc, {
+      behaviour: { type: 'random-walk', intervalMs: 0 },
+      worldRef: { id: 'overworld' },
+    });
+
+    controller.update(500, { worldRef: { id: 'overworld' } });
+
+    expect(movement.performRandomMovement).toHaveBeenCalledWith({ id: 'overworld' });
+  });
+
+  it('flags lifecycle changes for monsters when combat resolves', () => {
+    const monster = {
+      uuid: 'monster-1',
+      sceneId: 'scene-monster',
+      behaviour: {
+        type: 'melee',
+        attack: { intervalMs: 0, windupMs: 0, damageMultiplier: 1 },
+        aggressionRange: 1,
+      },
+      state: {
+        mode: 'idle',
+        targetId: null,
+        lastDecisionAt: 0,
+        lastStepAt: 0,
+        lastAttackAt: 0,
+        lastBroadcastAt: 0,
+        pendingAttack: { resolveAt: 0 },
+        patrolTarget: { x: 0, y: 0 },
+        respawnAt: null,
+      },
+      spawn: { x: 0, y: 0 },
+      isAlive: true,
+      resolvePendingAttack: vi.fn(() => {
+        monster.state.pendingAttack = null;
+        return true;
+      }),
+      resolveTarget: vi.fn(() => null),
+      tryAttack: vi.fn(() => false),
+      pursue: vi.fn(() => false),
+      returnToSpawn: vi.fn(() => false),
+      patrol: vi.fn(() => false),
+      respawnNow: vi.fn(() => true),
+      setFacing: vi.fn(),
+      setAnimationState: vi.fn(),
+    };
+
+    const controller = createMonsterAIController(monster);
+    const dirty = controller.update(1_000);
+
+    expect(monster.resolvePendingAttack).toHaveBeenCalledWith(1_000);
+    expect(dirty).toBe(true);
+
+    const secondDirty = controller.update(2_000);
+    expect(secondDirty).toBe(false);
+  });
+});

--- a/tests/server/unit/movement-system.spec.js
+++ b/tests/server/unit/movement-system.spec.js
@@ -1,0 +1,100 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import createMovementSystem from '#server/core/systems/movement-system.js';
+import { createWorld } from '#server/core/systems/ecs/factory.js';
+import { socketBroadcastMock } from '../mocks/socket.js';
+
+const buildEntity = (world, { id, type, handler }) => {
+  const entity = world.createEntity(id);
+  const transform = {
+    x: 0,
+    y: 0,
+    facing: 'south',
+    movementStep: { sequence: 1, startedAt: 0, direction: 'east' },
+  };
+
+  entity.addComponent('transform', transform);
+  entity.addComponent('movement-state', { handler, playerIndex: 0 });
+  entity.addComponent('movement-intent', { queue: [{ type: 'move', direction: 'east' }], current: null });
+  entity.addComponent('identity', { type, id, uuid: `${id}:uuid` });
+  entity.addComponent('networking', { broadcast: vi.fn(), broadcastKey: id });
+  world.addEntity(entity);
+  return entity;
+};
+
+describe('movement system', () => {
+  let world;
+  let movementSystem;
+
+  beforeEach(() => {
+    world = createWorld();
+    movementSystem = createMovementSystem();
+  });
+
+  it.each([
+    ['player'],
+    ['npc'],
+    ['monster'],
+  ])('processes movement intents and broadcasts updates for %s entities', (type) => {
+    const handler = { move: vi.fn(() => true) };
+    const entity = buildEntity(world, { id: `${type}:1`, type, handler });
+
+    movementSystem(world, 16, { now: 1_000 });
+
+    expect(handler.move).toHaveBeenCalledWith('east', {});
+
+    const movementState = entity.getComponent('movement-state');
+    expect(movementState.lastIntentType).toBe('move');
+
+    const intentComponent = entity.getComponent('movement-intent');
+    expect(intentComponent.current).toBeNull();
+    expect(intentComponent.queue).toHaveLength(0);
+    expect(intentComponent.last).toMatchObject({ type: 'move', direction: 'east' });
+
+    const broadcast = entity.getComponent('networking').broadcast;
+    expect(broadcast).toHaveBeenCalledTimes(1);
+    const [event, payload, recipients, options] = broadcast.mock.calls[0];
+    expect(event).toBe(`${type}:movement`);
+    expect(payload).toMatchObject({
+      type,
+      uuid: `${type}:1:uuid`,
+      x: 0,
+      y: 0,
+      facing: 'south',
+    });
+    expect(recipients).toBeNull();
+    expect(typeof options.meta.sentAt).toBe('number');
+  });
+
+  it('does not re-broadcast movement when the signature is unchanged', () => {
+    const handler = { move: vi.fn(() => true) };
+    const entity = buildEntity(world, { id: 'player:cache', type: 'player', handler });
+    const networking = entity.getComponent('networking');
+    networking.broadcast = vi.fn((...args) => socketBroadcastMock(...args));
+
+    movementSystem(world, 16, { now: 2_000 });
+    movementSystem(world, 16, { now: 2_016 });
+
+    expect(handler.move).toHaveBeenCalledTimes(1);
+    expect(networking.broadcast).toHaveBeenCalledTimes(1);
+    expect(socketBroadcastMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('requeues intents when handlers indicate failure with requeueOnFail', () => {
+    const handler = { move: vi.fn(() => false) };
+    const entity = buildEntity(world, { id: 'npc:retry', type: 'npc', handler });
+    const intentComponent = entity.getComponent('movement-intent');
+    intentComponent.queue = [];
+    intentComponent.current = {
+      type: 'move',
+      direction: 'north',
+      requeueOnFail: true,
+      consumeOnFalse: false,
+    };
+
+    movementSystem(world, 16, { now: 3_000 });
+
+    expect(handler.move).toHaveBeenCalledWith('north', {});
+    expect(intentComponent.current).toBeNull();
+    expect(intentComponent.queue[0]).toMatchObject({ type: 'move', direction: 'north' });
+  });
+});

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -20,9 +20,12 @@ const resolveEnvironment = () => {
 export default mergeConfig(viteConfig, defineConfig({
   test: {
     environment: resolveEnvironment(),
-    include: ['tests/unit/**/*.spec.js'],
+    include: ['tests/unit/**/*.spec.js', 'tests/server/**/*.spec.js'],
     globals: true,
     setupFiles: ['./tests/unit/setup.js'],
+    environmentMatchGlobs: [
+      ['tests/server/**/*.spec.js', 'node'],
+    ],
     exclude: ['tests/e2e/**', 'node_modules/**', 'dist/**', 'build/**'],
     coverage: {
       provider: 'v8',


### PR DESCRIPTION
## Summary
- add server-side unit tests for the movement, action queue, and AI controller systems covering players, NPCs, and monsters
- introduce an integration suite that simulates mixed-entity scene ticks while asserting movement, combat, and broadcast side effects
- provide reusable Socket/axios mocks and update Vitest configuration so the new server suites run under the node environment

## Testing
- npm run test:unit

------
https://chatgpt.com/codex/tasks/task_e_69056cc944c48321992cc1626adbfd64