### PR TITLE
Fix Chatbox CSS lint errors

### DIFF
--- a/src/components/Chatbox.vue
+++ b/src/components/Chatbox.vue
@@ -326,7 +326,9 @@ export default {
   flex-direction: column;
   width: var(--chat-width);
   max-width: 100%;
+
   @include glass-panel(rgba(16, 20, 32, 0.78));
+
   border-radius: var(--radius-lg);
   overflow: hidden;
   transition: transform 180ms ease-out, opacity 180ms ease-out;
@@ -443,7 +445,7 @@ export default {
 }
 
 .chatbox__text {
-  word-break: break-word;
+  overflow-wrap: anywhere;
 }
 
 .chatbox__text--chat {


### PR DESCRIPTION
## Summary
- insert the blank lines required by stylelint around the Chatbox mixin usage
- replace the deprecated `word-break: break-word` declaration with `overflow-wrap: anywhere`

## Testing
- npm run lint:css
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_69057c13386c832194cc818717a938bc