### PR TITLE
Fix WebSocket import and harden socket tests

### DIFF
--- a/server/socket.js
+++ b/server/socket.js
@@ -1,4 +1,4 @@
-import { WebSocketServer } from 'ws';
+import { WebSocketServer, WebSocket } from 'ws';
 import world from '#server/core/world.js';
 
 /**


### PR DESCRIPTION
## Summary
- import the WebSocket constant in the socket helper so readiness checks do not rely on a global
- expand the socket unit tests to cover emit/broadcast flows while asserting behaviour with the ws readiness constants

## Testing
- npm run test:unit

------
https://chatgpt.com/codex/tasks/task_e_690642a750e08321a7f69e0e58dd890a