### PR TITLE
Handle missing shop when building context menu

### DIFF
--- a/server/core/context-menu.js
+++ b/server/core/context-menu.js
@@ -313,7 +313,17 @@ class ContextMenu {
       q => q.npcId === this.player.objectId,
     );
 
-    return world.shops[shopIndex].inventory;
+    if (shopIndex === -1) {
+      console.warn(`ContextMenu: no shop found for NPC ${this.player.objectId}`);
+      return [];
+    }
+
+    const shop = world.shops[shopIndex];
+    if (!shop || !Array.isArray(shop.inventory)) {
+      return [];
+    }
+
+    return shop.inventory;
   }
 
   /**

--- a/tests/unit/context-menu.spec.js
+++ b/tests/unit/context-menu.spec.js
@@ -147,6 +147,34 @@ describe('ContextMenu strategies', () => {
     expect(takeActions[0].type).toBe('item');
   });
 
+  it('returns an empty shop inventory when interacting with an NPC without a shop', () => {
+    player.objectId = 'npc-1';
+    world.shops = [];
+
+    const miscData = {
+      clickedOn: {
+        0: 'gameMap',
+        1: 'inventorySlot',
+        2: 'bankSlot',
+        3: 'shopSlot',
+      },
+      slot: 0,
+    };
+
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const menu = new ContextMenu(player, tile, miscData);
+
+    let inventory;
+    expect(() => {
+      inventory = menu.getShopInventory();
+    }).not.toThrow();
+    expect(inventory).toEqual([]);
+    expect(warnSpy).toHaveBeenCalledWith('ContextMenu: no shop found for NPC npc-1');
+
+    warnSpy.mockRestore();
+  });
+
   it('generates bank quantity options while on the bank pane', async () => {
     player.currentPane = 'bank';
     player.inventory.slots = [{ slot: 0, id: 3 }];


### PR DESCRIPTION
## Description
- guard against missing shop entries when retrieving NPC inventories
- add a regression test covering the NPC-without-shop context

## Testing
- npm run test:unit

------
https://chatgpt.com/codex/tasks/task_e_6906489c324883218a4b111e24be4dc5