### PR TITLE
Add combat combat config module and hydrate loaders

### DIFF
--- a/src/core/client.js
+++ b/src/core/client.js
@@ -17,6 +17,7 @@ import { PLAYER_SPRITE_CONFIG } from './config/animation.js';
 import { DEFAULT_FACING_DIRECTION } from '@shared/combat.js';
 import { createCharacterState, syncShortcuts } from '@shared/stats/index.js';
 import { DEFAULT_MOVE_DURATION_MS, now } from './config/movement.js';
+import { hydrateMonsters } from './config/combat/index.js';
 
 import Map from './map.js';
 
@@ -110,7 +111,7 @@ class Client {
     this.players = [];
     this.droppedItems = data.droppedItems;
     this.npcs = data.npcs;
-    this.monsters = data.monsters || [];
+    this.monsters = hydrateMonsters(data.monsters || []);
     this.sceneId = (data.scene && data.scene.id) || data.sceneId || null;
     this.sceneMetadata = data.scene && data.scene.metadata ? data.scene.metadata : {};
     this.cachedImages = null;
@@ -196,7 +197,7 @@ class Client {
 
     this.droppedItems = scenePayload.droppedItems || [];
     this.npcs = scenePayload.npcs || [];
-    this.monsters = scenePayload.monsters || [];
+    this.monsters = hydrateMonsters(scenePayload.monsters || []);
 
     if (!this.player.movement) {
       this.player.movement = new MovementController().initialise(this.player.x, this.player.y);

--- a/src/core/config/combat/abilities.js
+++ b/src/core/config/combat/abilities.js
@@ -1,0 +1,102 @@
+// Ability configuration values consumed by the client combat systems.
+//
+// The definitions lean on the shared schema types declared in schema.js via
+// JSDoc annotations so that tooling can infer shapes without introducing a
+// compile step.
+
+/** @typedef {import('./schema.js').AbilityDefinition} AbilityDefinition */
+
+/**
+ * @type {AbilityDefinition[]}
+ */
+export const ABILITIES = [
+  {
+    id: 'cleaving-strike',
+    name: 'Cleaving Strike',
+    description: 'A wide, arcing swing that damages enemies in front of you.',
+    category: 'active',
+    cooldown: 6000,
+    resourceCost: { stamina: 20 },
+    effects: [
+      {
+        id: 'cleave-damage',
+        type: 'damage',
+        magnitude: 28,
+        damageType: 'physical',
+        description: 'Deals heavy physical damage in a frontal cone.',
+      },
+    ],
+    tags: ['melee', 'aoe'],
+  },
+  {
+    id: 'pinning-shot',
+    name: 'Pinning Shot',
+    description: 'Fires an arrow that slows the first enemy hit.',
+    category: 'active',
+    cooldown: 9000,
+    resourceCost: { stamina: 15 },
+    effects: [
+      {
+        id: 'pinning-shot-damage',
+        type: 'damage',
+        magnitude: 22,
+        damageType: 'physical',
+        description: 'Deals piercing damage to a single target.',
+      },
+      {
+        id: 'pinning-shot-slow',
+        type: 'control',
+        magnitude: 40,
+        duration: 5000,
+        description: 'Reduces the target\'s movement speed for 5 seconds.',
+      },
+    ],
+    tags: ['ranged', 'control'],
+  },
+  {
+    id: 'arcane-bolt',
+    name: 'Arcane Bolt',
+    description: 'Channels arcane energy into a focused projectile.',
+    category: 'active',
+    cooldown: 4500,
+    resourceCost: { mana: 18 },
+    effects: [
+      {
+        id: 'arcane-bolt-damage',
+        type: 'damage',
+        magnitude: 30,
+        damageType: 'arcane',
+        description: 'Deals arcane damage to a single target.',
+      },
+    ],
+    tags: ['magic', 'projectile'],
+  },
+  {
+    id: 'vital-surge',
+    name: 'Vital Surge',
+    description: 'Channel restorative energy that mends wounds over time.',
+    category: 'active',
+    cooldown: 12000,
+    resourceCost: { mana: 25 },
+    effects: [
+      {
+        id: 'vital-surge-heal',
+        type: 'heal',
+        magnitude: 32,
+        duration: 6000,
+        description: 'Heals the target over 6 seconds.',
+      },
+      {
+        id: 'vital-surge-fortify',
+        type: 'buff',
+        magnitude: 10,
+        duration: 6000,
+        stat: 'defense',
+        description: 'Increases defense while the heal is active.',
+      },
+    ],
+    tags: ['support', 'heal'],
+  },
+];
+
+export default ABILITIES;

--- a/src/core/config/combat/index.js
+++ b/src/core/config/combat/index.js
@@ -1,0 +1,208 @@
+import ABILITIES from './abilities.js';
+import MONSTERS from './monsters.js';
+import SPELLS from './spells.js';
+import WEAPONS from './weapons.js';
+
+/** @typedef {import('./schema.js').AbilityDefinition} AbilityDefinition */
+/** @typedef {import('./schema.js').MonsterDefinition} MonsterDefinition */
+/** @typedef {import('./schema.js').SpellDefinition} SpellDefinition */
+/** @typedef {import('./schema.js').WeaponDefinition} WeaponDefinition */
+
+const toMap = (collection = []) => new Map(collection.map((entry) => [entry.id, entry]));
+
+const abilityMap = toMap(ABILITIES);
+const weaponMap = toMap(WEAPONS);
+const spellMap = toMap(SPELLS);
+const monsterMap = toMap(MONSTERS);
+
+let cachedItemMap = new Map();
+let cachedCatalog = [];
+
+const cloneGraphics = (graphics = {}) => ({
+  ...graphics,
+  quantityLevel: Array.isArray(graphics.quantityLevel)
+    ? [...graphics.quantityLevel]
+    : graphics.quantityLevel,
+});
+
+const cloneItem = (item) => ({
+  ...item,
+  abilityIds: Array.isArray(item.abilityIds) ? [...item.abilityIds] : item.abilityIds,
+  graphics: cloneGraphics(item.graphics || {}),
+});
+
+const buildBaseItemDescriptors = () => {
+  const weaponItems = WEAPONS.map((weapon) => ({
+    id: weapon.id,
+    name: weapon.name,
+    description: weapon.description,
+    type: 'weapon',
+    slot: 'weapon',
+    stackable: weapon.stackable ?? false,
+    maxStack: weapon.maxStack ?? 1,
+    graphics: cloneGraphics({
+      tileset: 'weapons',
+      column: 0,
+      row: 0,
+      ...weapon.graphics,
+    }),
+    abilityIds: Array.isArray(weapon.abilityIds) ? [...weapon.abilityIds] : [],
+    damageType: weapon.damageType,
+    rarity: weapon.rarity || 'common',
+    weaponClass: weapon.weaponClass,
+  }));
+
+  const spellItems = SPELLS.filter((spell) => spell.itemizable).map((spell) => ({
+    id: spell.id,
+    name: spell.name,
+    description: spell.description,
+    type: 'spell',
+    slot: 'spellbook',
+    stackable: spell.stackable ?? false,
+    maxStack: spell.maxStack ?? 1,
+    graphics: cloneGraphics({
+      tileset: 'general',
+      column: 0,
+      row: 0,
+      ...spell.graphics,
+    }),
+    abilityIds: Array.isArray(spell.abilityIds) ? [...spell.abilityIds] : [],
+    damageType: spell.damageType,
+    rarity: spell.rarity || 'uncommon',
+  }));
+
+  return [...weaponItems, ...spellItems];
+};
+
+const BASE_ITEM_DESCRIPTORS = buildBaseItemDescriptors();
+
+const refreshItemCache = (itemsMap) => {
+  cachedItemMap = new Map(itemsMap);
+  cachedCatalog = Array.from(cachedItemMap.values()).map((item) => cloneItem(item));
+};
+
+refreshItemCache(new Map(BASE_ITEM_DESCRIPTORS.map((item) => [item.id, cloneItem(item)])));
+
+export const getAbilityDefinition = (id) => abilityMap.get(id) || null;
+export const getWeaponDefinition = (id) => weaponMap.get(id) || null;
+export const getSpellDefinition = (id) => spellMap.get(id) || null;
+export const getMonsterDefinition = (id) => monsterMap.get(id) || null;
+
+export const listAbilities = () => [...abilityMap.values()].map((ability) => ({ ...ability }));
+export const listWeapons = () => [...weaponMap.values()].map((weapon) => ({ ...weapon, graphics: cloneGraphics(weapon.graphics || {}) }));
+export const listSpells = () => [...spellMap.values()].map((spell) => ({ ...spell, graphics: cloneGraphics(spell.graphics || {}) }));
+export const listMonsters = () => [...monsterMap.values()].map((monster) => ({ ...monster, graphics: cloneGraphics(monster.graphics || {}) }));
+
+const toAbilityId = (ability) => {
+  if (!ability) {
+    return '';
+  }
+
+  const value = typeof ability === 'string' ? ability : ability.id;
+  return typeof value === 'string' ? value.trim() : '';
+};
+
+export const hydrateMonster = (monster) => {
+  if (!monster || typeof monster !== 'object') {
+    return monster;
+  }
+
+  const base = monster.id ? monsterMap.get(monster.id) : null;
+  const abilityIds = Array.isArray(monster.abilityIds)
+    ? monster.abilityIds.map((entry) => toAbilityId(entry)).filter(Boolean)
+    : Array.isArray(base?.abilityIds)
+      ? base.abilityIds.map((entry) => toAbilityId(entry)).filter(Boolean)
+      : [];
+
+  const resolvedAbilities = abilityIds
+    .map((abilityId) => abilityMap.get(abilityId))
+    .filter((ability) => ability);
+
+  return {
+    ...(base ? { ...base } : {}),
+    ...monster,
+    abilityIds,
+    abilityDefinitions: resolvedAbilities.map((ability) => ({ ...ability })),
+    stats: {
+      ...(base?.stats || {}),
+      ...(monster.stats || {}),
+    },
+    graphics: cloneGraphics({
+      ...(base?.graphics || {}),
+      ...(monster.graphics || {}),
+    }),
+    lootTable: Array.isArray(monster.lootTable)
+      ? monster.lootTable.map((entry) => ({ ...entry }))
+      : Array.isArray(base?.lootTable)
+        ? base.lootTable.map((entry) => ({ ...entry }))
+        : [],
+  };
+};
+
+export const hydrateMonsters = (monsters = []) => monsters.map((monster) => hydrateMonster(monster));
+
+export const buildItemCatalog = (serverItems = []) => {
+  const descriptorMap = new Map(BASE_ITEM_DESCRIPTORS.map((item) => [item.id, cloneItem(item)]));
+
+  serverItems.forEach((item) => {
+    if (!item || !item.id) {
+      return;
+    }
+
+    const existing = descriptorMap.get(item.id);
+    if (existing) {
+      descriptorMap.set(item.id, {
+        ...existing,
+        ...item,
+        graphics: cloneGraphics({
+          ...(existing.graphics || {}),
+          ...(item.graphics || {}),
+        }),
+      });
+      return;
+    }
+
+    descriptorMap.set(item.id, cloneItem(item));
+  });
+
+  refreshItemCache(descriptorMap);
+
+  return cachedCatalog.map((item) => cloneItem(item));
+};
+
+export const getItemDefinition = (id) => {
+  const item = cachedItemMap.get(id);
+  return item ? cloneItem(item) : null;
+};
+
+export const applyItemCatalogToWindow = (serverItems = []) => {
+  const catalog = buildItemCatalog(serverItems);
+  if (typeof window !== 'undefined') {
+    window.allItems = catalog.map((item) => cloneItem(item));
+  }
+  return catalog;
+};
+
+if (typeof window !== 'undefined' && !Array.isArray(window.allItems)) {
+  applyItemCatalogToWindow();
+}
+
+export default {
+  abilities: ABILITIES,
+  monsters: MONSTERS,
+  spells: SPELLS,
+  weapons: WEAPONS,
+  applyItemCatalogToWindow,
+  buildItemCatalog,
+  getAbilityDefinition,
+  getItemDefinition,
+  getMonsterDefinition,
+  getSpellDefinition,
+  getWeaponDefinition,
+  hydrateMonster,
+  hydrateMonsters,
+  listAbilities,
+  listMonsters,
+  listSpells,
+  listWeapons,
+};

--- a/src/core/config/combat/monsters.js
+++ b/src/core/config/combat/monsters.js
@@ -1,0 +1,63 @@
+// Monster configuration entries used to enrich server payloads.
+
+/** @typedef {import('./schema.js').MonsterDefinition} MonsterDefinition */
+
+/**
+ * @type {MonsterDefinition[]}
+ */
+export const MONSTERS = [
+  {
+    id: 'forest-slime',
+    name: 'Forest Slime',
+    level: 3,
+    behavior: 'defensive',
+    resistances: ['poison'],
+    weaknesses: ['fire'],
+    stats: {
+      health: 120,
+      mana: 0,
+      attack: 9,
+      defense: 6,
+      speed: 1.2,
+    },
+    abilityIds: ['cleaving-strike'],
+    lootTable: [
+      { itemId: 'iron-longblade', chance: 0.05 },
+      { itemId: 'spell-healing-mist', chance: 0.12 },
+    ],
+    graphics: {
+      tileset: 'monsters',
+      column: 2,
+      row: 1,
+    },
+    description: 'A docile slime that retaliates when cornered in the forest canopy.',
+  },
+  {
+    id: 'ember-wisp',
+    name: 'Ember Wisp',
+    level: 6,
+    behavior: 'aggressive',
+    resistances: ['fire'],
+    weaknesses: ['ice', 'water'],
+    stats: {
+      health: 160,
+      mana: 60,
+      attack: 14,
+      defense: 8,
+      speed: 1.6,
+    },
+    abilityIds: ['arcane-bolt'],
+    lootTable: [
+      { itemId: 'apprentice-focus', chance: 0.08 },
+      { itemId: 'spell-fireball', chance: 0.18 },
+    ],
+    graphics: {
+      tileset: 'monsters',
+      column: 6,
+      row: 0,
+    },
+    description: 'A flickering mote of wildfire drawn to unwary travellers.',
+  },
+];
+
+export default MONSTERS;

--- a/src/core/config/combat/schema.js
+++ b/src/core/config/combat/schema.js
@@ -1,0 +1,108 @@
+/**
+ * @typedef {'physical'|'fire'|'ice'|'lightning'|'poison'|'shadow'|'holy'|'arcane'} DamageType
+ */
+
+/**
+ * @typedef {'damage'|'heal'|'buff'|'debuff'|'control'} EffectKind
+ */
+
+/**
+ * @typedef {Object} Effect
+ * @property {string} id Identifier for the effect instance.
+ * @property {EffectKind} type Category of outcome the effect produces.
+ * @property {number} magnitude Relative strength of the effect.
+ * @property {number} [duration] Duration in milliseconds that the effect persists.
+ * @property {DamageType} [damageType] Elemental alignment of damage or mitigation.
+ * @property {string} [stat] Identifier of the stat that is influenced (attack, defense, etc.).
+ * @property {string} [description] Human readable summary displayed to players.
+ */
+
+/**
+ * @typedef {'active'|'passive'} AbilityCategory
+ */
+
+/**
+ * @typedef {Object} AbilityDefinition
+ * @property {string} id Unique id of the ability.
+ * @property {string} name Display name shown in tooltips.
+ * @property {string} description Rich text description of the effect.
+ * @property {AbilityCategory} category Whether the ability must be triggered or is always-on.
+ * @property {number} [cooldown] Cooldown period in milliseconds.
+ * @property {Record<string, number>} [resourceCost] Resource costs keyed by resource id.
+ * @property {Effect[]} effects The list of effects applied when the ability resolves.
+ * @property {string[]} [tags] Optional list of semantic tags that help group abilities.
+ */
+
+/**
+ * @typedef {'melee'|'ranged'|'magic'} WeaponClass
+ */
+
+/**
+ * @typedef {Object} WeaponDefinition
+ * @property {string} id Unique weapon identifier.
+ * @property {string} name Localised name used in UI.
+ * @property {string} description Tooltip text describing the weapon.
+ * @property {WeaponClass} weaponClass Category of the weapon.
+ * @property {DamageType} damageType Dominant elemental damage type.
+ * @property {[number, number]} damageRange Minimum and maximum base damage.
+ * @property {number} attackSpeed Milliseconds between primary attacks.
+ * @property {number} weight Weight rating that impacts encumbrance.
+ * @property {boolean} [twoHanded=false] Indicates if the weapon consumes both hands.
+ * @property {number} [range] Maximum tiles the weapon can target.
+ * @property {string[]} [abilityIds] Ability ids unlocked while the weapon is equipped.
+ * @property {Object} graphics Tileset metadata for rendering (tileset, column, row, quantityLevel).
+ * @property {boolean} [stackable=false] Whether the weapon can stack in inventory.
+ * @property {number} [maxStack=1] Maximum quantity per inventory stack when stackable.
+ * @property {string} [rarity='common'] Rarity tier for drop tables.
+ */
+
+/**
+ * @typedef {Object} SpellDefinition
+ * @property {string} id Unique spell identifier.
+ * @property {string} name Display name.
+ * @property {string} description Tooltip shown to players.
+ * @property {DamageType} damageType Elemental alignment of the spell.
+ * @property {number} castTime Casting time in milliseconds.
+ * @property {number} cooldown Cooldown in milliseconds.
+ * @property {Record<string, number>} resourceCost Resources consumed (mana, energy, etc.).
+ * @property {number} [range] Maximum targeting range.
+ * @property {string[]} [abilityIds] Ids of abilities or modifiers triggered by the spell.
+ * @property {Effect[]} effects The effects produced on hit or completion.
+ * @property {boolean} [itemizable=false] When true the spell can exist as an inventory item.
+ * @property {Object} graphics Tileset metadata for rendering.
+ * @property {boolean} [stackable=false] Whether the spell item stacks in inventory.
+ * @property {number} [maxStack=1] Maximum quantity per stack for spell tomes or scrolls.
+ */
+
+/**
+ * @typedef {Object} LootTableEntry
+ * @property {string} itemId Item identifier awarded.
+ * @property {number} chance Drop chance between 0 and 1.
+ * @property {[number, number]} [quantityRange] Range of quantities granted.
+ */
+
+/**
+ * @typedef {Object} StatBlock
+ * @property {number} health Maximum health pool.
+ * @property {number} [mana] Maximum mana pool.
+ * @property {number} attack Attack rating for melee/ranged strikes.
+ * @property {number} defense Damage mitigation rating.
+ * @property {number} speed Tiles moved per second or initiative modifier.
+ */
+
+/**
+ * @typedef {Object} MonsterDefinition
+ * @property {string} id Unique monster identifier.
+ * @property {string} name Monster name.
+ * @property {number} level Intended encounter level.
+ * @property {string} behavior Behavioral profile (aggressive, defensive, etc.).
+ * @property {DamageType[]} [resistances] Damage types that are resisted.
+ * @property {DamageType[]} [weaknesses] Damage types that deal extra damage.
+ * @property {StatBlock} stats Baseline stats for scaling calculations.
+ * @property {string[]} [abilityIds] Abilities the monster can execute.
+ * @property {LootTableEntry[]} [lootTable] Loot rolled on defeat.
+ * @property {Object} graphics Tileset metadata for the sprite sheet.
+ * @property {string} [description] Optional lore text displayed on inspection.
+ */
+
+export default {};

--- a/src/core/config/combat/spells.js
+++ b/src/core/config/combat/spells.js
@@ -1,0 +1,83 @@
+// Spell configuration entries powering spellbooks and scroll items.
+
+/** @typedef {import('./schema.js').SpellDefinition} SpellDefinition */
+
+/**
+ * @type {SpellDefinition[]}
+ */
+export const SPELLS = [
+  {
+    id: 'spell-fireball',
+    name: 'Fireball',
+    description: 'Hurl a fiery orb that explodes on impact.',
+    damageType: 'fire',
+    castTime: 2500,
+    cooldown: 8000,
+    resourceCost: { mana: 30 },
+    range: 7,
+    abilityIds: ['arcane-bolt'],
+    effects: [
+      {
+        id: 'fireball-impact',
+        type: 'damage',
+        magnitude: 40,
+        damageType: 'fire',
+        description: 'Deals fire damage to the primary target.',
+      },
+      {
+        id: 'fireball-burn',
+        type: 'damage',
+        magnitude: 12,
+        duration: 6000,
+        damageType: 'fire',
+        description: 'Applies a burning damage over time effect.',
+      },
+    ],
+    itemizable: true,
+    graphics: {
+      tileset: 'general',
+      column: 5,
+      row: 3,
+    },
+    stackable: false,
+    maxStack: 1,
+  },
+  {
+    id: 'spell-healing-mist',
+    name: 'Healing Mist',
+    description: 'Envelop allies in a soothing restorative mist.',
+    damageType: 'holy',
+    castTime: 2000,
+    cooldown: 12000,
+    resourceCost: { mana: 35 },
+    range: 5,
+    abilityIds: ['vital-surge'],
+    effects: [
+      {
+        id: 'healing-mist-heal',
+        type: 'heal',
+        magnitude: 28,
+        duration: 5000,
+        description: 'Restores health to allies within the mist.',
+      },
+      {
+        id: 'healing-mist-resist',
+        type: 'buff',
+        magnitude: 8,
+        duration: 5000,
+        stat: 'defense',
+        description: 'Grants a modest defense increase while active.',
+      },
+    ],
+    itemizable: true,
+    graphics: {
+      tileset: 'general',
+      column: 1,
+      row: 5,
+    },
+    stackable: false,
+    maxStack: 1,
+  },
+];
+
+export default SPELLS;

--- a/src/core/config/combat/weapons.js
+++ b/src/core/config/combat/weapons.js
@@ -1,0 +1,70 @@
+// Weapon configuration definitions for the combat subsystem.
+
+/** @typedef {import('./schema.js').WeaponDefinition} WeaponDefinition */
+
+/**
+ * @type {WeaponDefinition[]}
+ */
+export const WEAPONS = [
+  {
+    id: 'iron-longblade',
+    name: 'Iron Longblade',
+    description: 'A reliable sword favoured by novice adventurers.',
+    weaponClass: 'melee',
+    damageType: 'physical',
+    damageRange: [12, 18],
+    attackSpeed: 1800,
+    weight: 6,
+    twoHanded: false,
+    abilityIds: ['cleaving-strike'],
+    graphics: {
+      tileset: 'weapons',
+      column: 1,
+      row: 2,
+    },
+    stackable: false,
+    maxStack: 1,
+    rarity: 'common',
+  },
+  {
+    id: 'oak-longbow',
+    name: 'Oak Longbow',
+    description: 'A finely crafted bow capable of impressive range.',
+    weaponClass: 'ranged',
+    damageType: 'physical',
+    damageRange: [10, 16],
+    attackSpeed: 2200,
+    weight: 4,
+    range: 6,
+    abilityIds: ['pinning-shot'],
+    graphics: {
+      tileset: 'weapons',
+      column: 7,
+      row: 1,
+    },
+    stackable: false,
+    maxStack: 1,
+    rarity: 'uncommon',
+  },
+  {
+    id: 'apprentice-focus',
+    name: 'Apprentice Focus',
+    description: 'A focus crystal attuned to the arcane currents.',
+    weaponClass: 'magic',
+    damageType: 'arcane',
+    damageRange: [8, 14],
+    attackSpeed: 1600,
+    weight: 2,
+    abilityIds: ['arcane-bolt', 'vital-surge'],
+    graphics: {
+      tileset: 'weapons',
+      column: 10,
+      row: 0,
+    },
+    stackable: false,
+    maxStack: 1,
+    rarity: 'uncommon',
+  },
+];
+
+export default WEAPONS;

--- a/src/core/inventory/legacy-adapter.js
+++ b/src/core/inventory/legacy-adapter.js
@@ -1,4 +1,5 @@
 import UI from '@shared/ui.js';
+import { getItemDefinition } from '../config/combat/index.js';
 
 const ensureSlot = (item, fallbackSlot) => {
   if (item && typeof item.slot === 'number') {
@@ -47,7 +48,7 @@ export const adaptLegacyGridItem = (source, slotIndex, options = {}) => {
   const slot = typeof options.slot === 'number' ? options.slot : ensureSlot(source, slotIndex);
   const itemId = options.id || source?.id || source;
   const qty = typeof options.qty === 'number' ? options.qty : (typeof source?.qty === 'number' ? source.qty : 1);
-  const itemData = itemId ? UI.getItemData(itemId) : null;
+  const itemData = itemId ? (getItemDefinition(itemId) || UI.getItemData(itemId)) : null;
   const graphicsSource = options.graphics || source?.graphics || itemData?.graphics || {};
 
   const graphics = cloneGraphics(graphicsSource, qty);

--- a/src/core/map.js
+++ b/src/core/map.js
@@ -8,6 +8,7 @@ import MovementController, { centerOfTile } from './utilities/movement-controlle
 import SpriteAnimator from './utilities/sprite-animator.js';
 import { PLAYER_SPRITE_CONFIG } from './config/animation.js';
 import { now } from './config/movement.js';
+import { getItemDefinition, hydrateMonsters } from './config/combat/index.js';
 
 const INITIAL_VIEWPORT = {
   x: config.map.viewport.x,
@@ -340,6 +341,8 @@ class Map {
         .filter((entry) => entry !== null),
     );
 
+    const incoming = hydrateMonsters(monsters || []);
+
     const movementEntries = Array.isArray(meta.movements) ? meta.movements : [];
     const movementLookup = new window.Map(
       movementEntries
@@ -366,7 +369,7 @@ class Map {
         .filter((entry) => entry !== null),
     );
 
-    this.monsters = (monsters || []).map((monster) => {
+    this.monsters = incoming.map((monster) => {
       const key = monster && (monster.uuid || monster.id);
       const previous = key ? existing.get(key) : null;
       const controller = previous && previous.movement
@@ -747,7 +750,10 @@ class Map {
       const screenPosition = this.worldToScreen(topLeft, metrics);
 
       // Get item information and get proper quantity index for graphic
-      const info = UI.getItemData(item.id);
+      const info = getItemDefinition(item.id) || UI.getItemData(item.id);
+      if (!info || !info.graphics) {
+        return;
+      }
       let qtyIndex = 0;
       if (item.qty > 1 && info.graphics.quantityLevel) {
         const qLevels = info.graphics.quantityLevel;

--- a/src/core/player/events.js
+++ b/src/core/player/events.js
@@ -6,6 +6,7 @@ import monsterEvents from './events/monster.js';
 import worldEvents from './events/world.js';
 import screenEvents from './events/screen.js';
 import partyEvents from './events/party.js';
+import { applyItemCatalogToWindow } from '../config/combat/index.js';
 
 /**
  * A global event handler [CLIENT SIDE] (RPC)
@@ -14,6 +15,10 @@ import partyEvents from './events/party.js';
  * @param {object} ws The Socket connection to incoming client
  * @param {object} context The server context
  */
+
+// Seed the client-side catalog with local configuration so that item lookups
+// succeed before the server sends its authoritative payload.
+applyItemCatalogToWindow();
 
 // These are events that come from the server that
 // will manipulate and change the client accordingly.
@@ -31,7 +36,10 @@ const handler = {
    * Receive the data from the client upon browser open
    */
   'server:send:items': (data) => {
-    window.allItems = data.data.items;
+    const payload = data && data.data && Array.isArray(data.data.items)
+      ? data.data.items
+      : [];
+    applyItemCatalogToWindow(payload);
   },
 };
 


### PR DESCRIPTION
## Summary
- introduce a combat configuration module with schema documentation plus baseline monster, weapon, spell, and ability definitions
- add registry helpers to hydrate monsters and merge item catalogs for window-driven lookups
- update player events, inventory adapters, the client, and map rendering to consume the shared combat config

## Testing
- npm run test:unit

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e6cfd38688321b5807093a5d6770a)