### PR TITLE
Add combat engine with resistance handling

### DIFF
--- a/src/core/combat-engine.js
+++ b/src/core/combat-engine.js
@@ -1,0 +1,671 @@
+import bus from './utilities/bus.js';
+import { getMonsterDefinition } from './config/combat/index.js';
+
+const DEFAULT_TICK_INTERVAL = 1000;
+const DEFAULT_RESISTANCE_VALUE = 0.25;
+const DEFAULT_WEAKNESS_VALUE = -0.25;
+
+const clone = (value) => {
+  if (value === null || typeof value !== 'object') {
+    return value;
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((entry) => clone(entry));
+  }
+
+  return Object.keys(value).reduce((acc, key) => {
+    acc[key] = clone(value[key]);
+    return acc;
+  }, {});
+};
+
+const normaliseNumber = (value, fallback = 0) => {
+  const number = Number(value);
+  return Number.isFinite(number) ? number : fallback;
+};
+
+const normaliseDamageType = (damageType) => {
+  if (typeof damageType !== 'string') {
+    return 'physical';
+  }
+
+  const lower = damageType.trim().toLowerCase();
+  return lower || 'physical';
+};
+
+const resolveResistanceValue = (value, fallback = 0) => {
+  if (typeof value === 'string') {
+    const parsed = Number.parseFloat(value);
+    if (Number.isFinite(parsed)) {
+      return parsed;
+    }
+  }
+
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value;
+  }
+
+  return fallback;
+};
+
+const clampResistance = (value) => {
+  if (!Number.isFinite(value)) {
+    return 0;
+  }
+
+  const clamped = Math.max(-0.95, Math.min(0.95, value));
+  return Math.round(clamped * 1000) / 1000;
+};
+
+const createHealthState = (entity = {}, baseStats = {}) => {
+  const statsHealth = normaliseNumber(entity?.stats?.health, baseStats?.health);
+  const max = normaliseNumber(entity?.health?.max, statsHealth || baseStats?.health || 1);
+  const current = normaliseNumber(entity?.health?.current, max);
+
+  return {
+    max: Math.max(1, Math.round(max)),
+    current: Math.max(0, Math.round(Math.min(current, max))),
+  };
+};
+
+const createResistanceProfile = (base = {}, entity = {}, options = {}) => {
+  const resistanceValue = options.defaultResistance ?? DEFAULT_RESISTANCE_VALUE;
+  const weaknessValue = options.defaultWeakness ?? DEFAULT_WEAKNESS_VALUE;
+
+  const resistanceMap = new Map();
+
+  const applyArray = (collection, value) => {
+    if (!Array.isArray(collection)) {
+      return;
+    }
+
+    collection.forEach((entry) => {
+      if (typeof entry !== 'string') {
+        return;
+      }
+
+      const key = normaliseDamageType(entry);
+      const current = resistanceMap.get(key) || 0;
+      resistanceMap.set(key, clampResistance(current + value));
+    });
+  };
+
+  const applyObject = (collection = {}) => {
+    Object.entries(collection).forEach(([key, value]) => {
+      if (typeof key !== 'string') {
+        return;
+      }
+
+      const resolved = resolveResistanceValue(value, 0);
+      const normalised = normaliseDamageType(key);
+      const current = resistanceMap.get(normalised) || 0;
+      resistanceMap.set(normalised, clampResistance(current + resolved));
+    });
+  };
+
+  applyArray(base?.resistances, resistanceValue);
+  applyArray(entity?.resistances, resistanceValue);
+  applyArray(entity?.stats?.resistances, resistanceValue);
+
+  applyArray(base?.weaknesses, weaknessValue);
+  applyArray(entity?.weaknesses, weaknessValue);
+  applyArray(entity?.stats?.weaknesses, weaknessValue);
+
+  if (base?.resistanceValues) {
+    applyObject(base.resistanceValues);
+  }
+  if (entity?.resistanceValues) {
+    applyObject(entity.resistanceValues);
+  }
+  if (entity?.stats?.resistanceValues) {
+    applyObject(entity.stats.resistanceValues);
+  }
+  if (entity?.resistances && !Array.isArray(entity.resistances)) {
+    applyObject(entity.resistances);
+  }
+  if (entity?.weaknesses && !Array.isArray(entity.weaknesses)) {
+    applyObject(entity.weaknesses);
+  }
+
+  return resistanceMap;
+};
+
+const buildBaseStats = (base = {}, entity = {}) => {
+  const stats = {
+    attack: 0,
+    defense: 0,
+    speed: 0,
+    ...clone(base?.stats || {}),
+    ...clone(entity?.stats || {}),
+  };
+
+  stats.attack = normaliseNumber(stats.attack, 0);
+  stats.defense = normaliseNumber(stats.defense, 0);
+  stats.speed = normaliseNumber(stats.speed, 0);
+
+  if (!Number.isFinite(stats.health) && Number.isFinite(base?.stats?.health)) {
+    stats.health = normaliseNumber(base.stats.health, 1);
+  } else if (Number.isFinite(stats.health)) {
+    stats.health = normaliseNumber(stats.health, 1);
+  }
+
+  return stats;
+};
+
+const computeHitChance = (attack, defense) => {
+  const attackScore = Math.max(1, attack);
+  const defenseScore = Math.max(1, defense);
+  const ratio = attackScore / (attackScore + defenseScore);
+  return Math.min(0.95, Math.max(0.05, Math.round(ratio * 1000) / 1000));
+};
+
+class CombatEngine {
+  constructor(options = {}) {
+    this.options = {
+      defaultResistance: DEFAULT_RESISTANCE_VALUE,
+      defaultWeakness: DEFAULT_WEAKNESS_VALUE,
+      ...options,
+    };
+
+    this.random = typeof options.random === 'function' ? options.random : () => Math.random();
+    this.bus = options.bus || bus;
+    this.entities = new Map();
+    this.effects = new Map();
+  }
+
+  registerEntity(entity) {
+    if (!entity || !entity.id) {
+      return null;
+    }
+
+    const templateId = entity.templateId || entity.monsterId || null;
+    const base = entity.kind === 'monster' || templateId
+      ? getMonsterDefinition(templateId || entity.id) || null
+      : null;
+
+    const stats = buildBaseStats(base, entity);
+    const health = createHealthState(entity, base?.stats || {});
+    const resistances = createResistanceProfile(base, entity, this.options);
+
+    const record = {
+      id: entity.id,
+      name: entity.name || base?.name || entity.id,
+      kind: entity.kind || (base ? 'monster' : 'player'),
+      stats,
+      modifiers: {},
+      resistances,
+      health,
+      state: entity.state || 'alive',
+      metadata: clone(entity.metadata || {}),
+    };
+
+    this.entities.set(record.id, record);
+    this.emitEntityUpdate(record);
+    return this.getEntity(record.id);
+  }
+
+  unregisterEntity(entityId) {
+    if (!this.entities.has(entityId)) {
+      return false;
+    }
+
+    this.entities.delete(entityId);
+    [...this.effects.values()].forEach((instance) => {
+      if (instance.targetId === entityId || instance.sourceId === entityId) {
+        this.effects.delete(instance.instanceId);
+      }
+    });
+    return true;
+  }
+
+  getEntity(entityId) {
+    const entity = this.entities.get(entityId);
+    if (!entity) {
+      return null;
+    }
+
+    return {
+      id: entity.id,
+      name: entity.name,
+      kind: entity.kind,
+      stats: clone(entity.stats),
+      modifiers: clone(entity.modifiers),
+      resistances: new Map(entity.resistances),
+      health: clone(entity.health),
+      state: entity.state,
+      metadata: clone(entity.metadata),
+    };
+  }
+
+  listEntities() {
+    return [...this.entities.keys()].map((id) => this.getEntity(id));
+  }
+
+  listActiveEffects(targetId = null) {
+    const entries = [...this.effects.values()].filter((instance) => {
+      if (!targetId) {
+        return true;
+      }
+      return instance.targetId === targetId;
+    });
+
+    return entries.map((instance) => ({
+      instanceId: instance.instanceId,
+      effect: { ...instance.effect },
+      sourceId: instance.sourceId,
+      targetId: instance.targetId,
+      stacks: instance.stacks,
+      maxStacks: instance.maxStacks,
+      tickInterval: instance.tickInterval,
+      timeUntilTick: instance.timeUntilTick,
+      remaining: instance.remaining,
+    }));
+  }
+
+  getEffectiveStat(entity, stat) {
+    const base = normaliseNumber(entity.stats?.[stat], 0);
+    const modifier = normaliseNumber(entity.modifiers?.[stat], 0);
+    return base + modifier;
+  }
+
+  getResistance(entity, damageType) {
+    if (!entity) {
+      return 0;
+    }
+
+    const key = normaliseDamageType(damageType);
+    return entity.resistances.get(key) || 0;
+  }
+
+  setResistance(entityId, damageType, value) {
+    const entity = this.entities.get(entityId);
+    if (!entity) {
+      return null;
+    }
+
+    const key = normaliseDamageType(damageType);
+    entity.resistances.set(key, clampResistance(resolveResistanceValue(value, 0)));
+    this.emitEntityUpdate(entity);
+    return this.getEntity(entityId);
+  }
+
+  performAttack(payload = {}) {
+    const attacker = this.entities.get(payload.attackerId);
+    const defender = this.entities.get(payload.defenderId);
+
+    if (!attacker || !defender) {
+      return { hit: false, reason: 'invalid-entity' };
+    }
+
+    if (defender.state === 'dead') {
+      return { hit: false, reason: 'target-dead' };
+    }
+
+    const attackerAttack = this.getEffectiveStat(attacker, 'attack');
+    const defenderDefense = this.getEffectiveStat(defender, 'defense');
+
+    const hitChance = computeHitChance(attackerAttack, defenderDefense);
+    const roll = this.random();
+    const hit = roll <= hitChance;
+
+    const damageType = normaliseDamageType(payload.damageType || 'physical');
+
+    const result = {
+      kind: 'attack',
+      attackerId: attacker.id,
+      defenderId: defender.id,
+      damageType,
+      hit,
+      roll,
+      hitChance,
+      damage: 0,
+    };
+
+    if (!hit) {
+      const missEvent = { ...result, kind: 'miss' };
+      this.emitEvent(missEvent);
+      return missEvent;
+    }
+
+    const baseDamage = resolveResistanceValue(payload.baseDamage, attackerAttack);
+    const rawDamage = this.computeRawDamage(baseDamage, attackerAttack);
+    const mitigated = this.applyMitigation(rawDamage, defender, damageType);
+    const appliedDamage = this.applyDamage(defender, mitigated);
+
+    const attackEvent = { ...result, damage: appliedDamage };
+    this.emitEvent(attackEvent);
+    return attackEvent;
+  }
+
+  computeRawDamage(baseDamage, attackStat) {
+    const base = Math.max(0, resolveResistanceValue(baseDamage, attackStat));
+    const scaling = Math.max(0, attackStat * 0.5);
+    const damage = base + scaling;
+    return Math.max(0, Math.round(damage));
+  }
+
+  applyMitigation(damage, defender, damageType) {
+    const defenseStat = this.getEffectiveStat(defender, 'defense');
+    const defenseMitigation = defenseStat <= 0 ? 0 : defenseStat / (defenseStat + 100);
+    const afterDefense = damage * (1 - defenseMitigation);
+    const resistanceValue = this.getResistance(defender, damageType);
+    const afterResistance = afterDefense * (1 - resistanceValue);
+    return Math.max(0, afterResistance);
+  }
+
+  applyDamage(defender, amount) {
+    const damage = Math.max(0, Math.round(amount));
+    defender.health.current = Math.max(0, defender.health.current - damage);
+
+    if (defender.health.current <= 0) {
+      defender.state = 'dead';
+    }
+
+    this.emitEntityUpdate(defender);
+
+    if (damage > 0) {
+      this.emitEvent({
+        kind: 'damage',
+        targetId: defender.id,
+        amount: damage,
+        remainingHealth: defender.health.current,
+      });
+    }
+
+    return damage;
+  }
+
+  applyHealing(targetId, amount) {
+    const target = this.entities.get(targetId);
+    if (!target) {
+      return 0;
+    }
+
+    const heal = Math.max(0, Math.round(amount));
+    if (heal <= 0) {
+      return 0;
+    }
+
+    const previous = target.health.current;
+    target.health.current = Math.min(target.health.max, target.health.current + heal);
+    if (target.health.current > 0 && target.state === 'dead') {
+      target.state = 'alive';
+    }
+
+    const applied = target.health.current - previous;
+    if (applied > 0) {
+      this.emitEntityUpdate(target);
+      this.emitEvent({
+        kind: 'heal',
+        targetId: target.id,
+        amount: applied,
+        remainingHealth: target.health.current,
+      });
+    }
+
+    return applied;
+  }
+
+  applyEffect(options = {}) {
+    const { effect, sourceId, targetId } = options;
+    if (!effect || !effect.id || !targetId) {
+      return null;
+    }
+
+    const target = this.entities.get(targetId);
+    if (!target) {
+      return null;
+    }
+
+    const source = sourceId ? this.entities.get(sourceId) : null;
+    const stacking = options.stacking || effect.stacking || 'refresh';
+    const maxStacks = options.maxStacks || effect.maxStacks || (stacking === 'stack' ? 3 : 1);
+    const tickInterval = options.tickInterval || effect.tickInterval || DEFAULT_TICK_INTERVAL;
+    const duration = effect.duration || options.duration || 0;
+
+    if (!duration) {
+      return this.resolveImmediateEffect({ effect, source, target, sourceId, targetId });
+    }
+
+    const instanceId = `${targetId}:${effect.id}`;
+    const existing = this.effects.get(instanceId);
+
+    if (existing) {
+      if (stacking === 'stack') {
+        existing.stacks = Math.min(maxStacks, existing.stacks + 1);
+        existing.remaining = Math.max(existing.remaining, duration);
+      } else {
+        existing.remaining = duration;
+        existing.stacks = Math.min(maxStacks, existing.stacks + 1);
+        existing.stacks = Math.min(existing.stacks, maxStacks);
+      }
+      existing.tickInterval = tickInterval;
+      this.emitEvent({
+        kind: 'effect-updated',
+        effectId: effect.id,
+        targetId,
+        stacks: existing.stacks,
+      });
+      return clone(existing);
+    }
+
+    const instance = {
+      instanceId,
+      effect: { ...effect },
+      sourceId: source ? source.id : sourceId || null,
+      targetId,
+      stacks: stacking === 'stack' ? 1 : Math.min(1, maxStacks),
+      maxStacks,
+      tickInterval,
+      timeUntilTick: tickInterval,
+      remaining: duration,
+    };
+
+    if (effect.type === 'buff' || effect.type === 'debuff') {
+      this.applyModifierEffect(instance, { effect, target, stacking });
+    }
+
+    this.effects.set(instanceId, instance);
+    this.emitEvent({
+      kind: 'effect-applied',
+      effectId: effect.id,
+      targetId,
+      sourceId: instance.sourceId,
+      stacks: instance.stacks,
+    });
+    return clone(instance);
+  }
+
+  resolveImmediateEffect({ effect, target, targetId, source, sourceId }) {
+    switch (effect.type) {
+    case 'damage': {
+      const attackerAttack = source ? this.getEffectiveStat(source, 'attack') : effect.magnitude;
+      const baseDamage = resolveResistanceValue(effect.magnitude, attackerAttack);
+      const rawDamage = this.computeRawDamage(baseDamage, attackerAttack);
+      const mitigated = this.applyMitigation(rawDamage, target, effect.damageType);
+      const applied = this.applyDamage(target, mitigated);
+      this.emitEvent({
+        kind: 'effect-damage',
+        effectId: effect.id,
+        sourceId: sourceId || null,
+        targetId,
+        amount: applied,
+      });
+      return applied;
+    }
+    case 'heal': {
+      const applied = this.applyHealing(targetId, effect.magnitude);
+      this.emitEvent({
+        kind: 'effect-heal',
+        effectId: effect.id,
+        sourceId: sourceId || null,
+        targetId,
+        amount: applied,
+      });
+      return applied;
+    }
+    case 'buff':
+    case 'debuff': {
+      this.applyModifierEffect(null, { effect, target });
+      return effect.magnitude;
+    }
+    default:
+      return 0;
+    }
+  }
+
+  applyModifierEffect(instance, context = {}) {
+    const { effect, target } = context;
+    if (!effect || !target) {
+      return;
+    }
+
+    const direction = effect.type === 'debuff' ? -1 : 1;
+    const modifierValue = direction * resolveResistanceValue(effect.magnitude, 0);
+
+    if (effect.stat) {
+      const current = target.modifiers[effect.stat] || 0;
+      target.modifiers[effect.stat] = current + modifierValue;
+      this.emitEntityUpdate(target);
+    }
+
+    if (effect.damageType) {
+      const existing = target.resistances.get(normaliseDamageType(effect.damageType)) || 0;
+      target.resistances.set(
+        normaliseDamageType(effect.damageType),
+        clampResistance(existing + (modifierValue / 100)),
+      );
+      this.emitEntityUpdate(target);
+    }
+
+    if (instance) {
+      instance.modifier = modifierValue;
+      instance.stat = effect.stat || null;
+      instance.resistanceType = effect.damageType ? normaliseDamageType(effect.damageType) : null;
+    }
+  }
+
+  advanceTime(deltaMs) {
+    if (!Number.isFinite(deltaMs) || deltaMs <= 0) {
+      return [];
+    }
+
+    const expired = [];
+
+    this.effects.forEach((instance, key) => {
+      instance.remaining -= deltaMs;
+      instance.timeUntilTick -= deltaMs;
+
+      while (instance.timeUntilTick <= 0 && instance.remaining >= -1) {
+        this.resolveEffectTick(instance);
+        instance.timeUntilTick += instance.tickInterval;
+      }
+
+      if (instance.remaining <= 0) {
+        expired.push(instance);
+        this.effects.delete(key);
+      }
+    });
+
+    expired.forEach((instance) => {
+      this.handleEffectExpiry(instance);
+    });
+
+    return expired.map((instance) => ({ ...instance }));
+  }
+
+  resolveEffectTick(instance) {
+    const target = this.entities.get(instance.targetId);
+    if (!target) {
+      return;
+    }
+
+    const stacks = Math.max(1, instance.stacks || 1);
+    const magnitude = resolveResistanceValue(instance.effect.magnitude, 0) * stacks;
+
+    switch (instance.effect.type) {
+    case 'damage': {
+      const rawDamage = this.computeRawDamage(magnitude, magnitude);
+      const mitigated = this.applyMitigation(rawDamage, target, instance.effect.damageType);
+      const applied = this.applyDamage(target, mitigated);
+      this.emitEvent({
+        kind: 'effect-tick',
+        tickType: 'damage',
+        effectId: instance.effect.id,
+        targetId: instance.targetId,
+        amount: applied,
+        stacks,
+      });
+      break;
+    }
+    case 'heal': {
+      const applied = this.applyHealing(instance.targetId, magnitude);
+      this.emitEvent({
+        kind: 'effect-tick',
+        tickType: 'heal',
+        effectId: instance.effect.id,
+        targetId: instance.targetId,
+        amount: applied,
+        stacks,
+      });
+      break;
+    }
+    default:
+      break;
+    }
+  }
+
+  handleEffectExpiry(instance) {
+    const target = this.entities.get(instance.targetId);
+
+    if ((instance.effect.type === 'buff' || instance.effect.type === 'debuff') && target) {
+      if (instance.stat) {
+        const current = target.modifiers[instance.stat] || 0;
+        target.modifiers[instance.stat] = current - (instance.modifier || 0);
+      }
+
+      if (instance.resistanceType) {
+        const current = target.resistances.get(instance.resistanceType) || 0;
+        target.resistances.set(
+          instance.resistanceType,
+          clampResistance(current - ((instance.modifier || 0) / 100)),
+        );
+      }
+
+      this.emitEntityUpdate(target);
+    }
+
+    this.emitEvent({
+      kind: 'effect-expired',
+      effectId: instance.effect.id,
+      targetId: instance.targetId,
+    });
+  }
+
+  emitEvent(event) {
+    const payload = {
+      ...event,
+      timestamp: event.timestamp || Date.now(),
+    };
+    this.bus.$emit('COMBAT:EVENT', payload);
+    return payload;
+  }
+
+  emitEntityUpdate(entity) {
+    this.bus.$emit('COMBAT:ENTITY_UPDATED', {
+      entity: {
+        id: entity.id,
+        name: entity.name,
+        kind: entity.kind,
+        stats: clone(entity.stats),
+        modifiers: clone(entity.modifiers),
+        health: clone(entity.health),
+        resistances: new Map(entity.resistances),
+        state: entity.state,
+      },
+    });
+  }
+}
+
+export default CombatEngine;

--- a/src/stores/combat.js
+++ b/src/stores/combat.js
@@ -1,0 +1,108 @@
+import { defineStore } from 'pinia';
+import bus from '../core/utilities/bus.js';
+
+const clone = (value) => {
+  if (!value || typeof value !== 'object') {
+    return value;
+  }
+
+  if (value instanceof Map) {
+    return new Map(value);
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((entry) => clone(entry));
+  }
+
+  return Object.entries(value).reduce((acc, [key, val]) => {
+    acc[key] = clone(val);
+    return acc;
+  }, {});
+};
+
+const appendEvent = (events, event, max = 50) => {
+  const next = [...events, event];
+  if (next.length > max) {
+    return next.slice(next.length - max);
+  }
+  return next;
+};
+
+export const useCombatStore = defineStore('combat', {
+  state: () => ({
+    log: [],
+    entities: {},
+    _subscribed: false,
+    _eventHandler: null,
+    _entityHandler: null,
+  }),
+  actions: {
+    ensureSubscriptions() {
+      if (this._subscribed) {
+        return;
+      }
+
+      const handleEvent = (event) => {
+        this.recordEvent(event);
+      };
+
+      const handleEntityUpdate = ({ entity }) => {
+        if (entity && entity.id) {
+          this.upsertEntity(entity);
+        }
+      };
+
+      bus.$on('COMBAT:EVENT', handleEvent);
+      bus.$on('COMBAT:ENTITY_UPDATED', handleEntityUpdate);
+
+      this._eventHandler = handleEvent;
+      this._entityHandler = handleEntityUpdate;
+      this._subscribed = true;
+    },
+    dispose() {
+      if (!this._subscribed) {
+        return;
+      }
+
+      if (this._eventHandler) {
+        bus.$off('COMBAT:EVENT', this._eventHandler);
+      }
+      if (this._entityHandler) {
+        bus.$off('COMBAT:ENTITY_UPDATED', this._entityHandler);
+      }
+
+      this._eventHandler = null;
+      this._entityHandler = null;
+      this._subscribed = false;
+    },
+    clearLog() {
+      this.log = [];
+    },
+    recordEvent(event) {
+      const entry = {
+        ...event,
+        timestamp: event?.timestamp || Date.now(),
+      };
+      this.log = appendEvent(this.log, entry);
+    },
+    upsertEntity(entity) {
+      if (!entity || !entity.id) {
+        return;
+      }
+
+      const existing = this.entities[entity.id] || {};
+      this.entities[entity.id] = {
+        ...existing,
+        ...clone(entity),
+        health: clone(entity.health) || existing.health || null,
+        stats: clone(entity.stats) || existing.stats || {},
+        modifiers: clone(entity.modifiers) || existing.modifiers || {},
+        resistances: entity.resistances instanceof Map
+          ? new Map(entity.resistances)
+          : clone(entity.resistances) || existing.resistances || new Map(),
+      };
+    },
+  },
+});
+
+export default useCombatStore;

--- a/tests/unit/combat.spec.ts
+++ b/tests/unit/combat.spec.ts
@@ -1,0 +1,222 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { createPinia, setActivePinia } from 'pinia';
+import CombatEngine from '../../src/core/combat-engine.js';
+import { useCombatStore } from '../../src/stores/combat.js';
+
+const HERO = {
+  id: 'hero',
+  kind: 'player',
+  name: 'Heroic Adventurer',
+  stats: {
+    attack: 35,
+    defense: 15,
+    health: 150,
+  },
+  health: {
+    current: 150,
+    max: 150,
+  },
+};
+
+const BASE_MONSTER = {
+  id: 'training-dummy',
+  kind: 'monster',
+  name: 'Training Dummy',
+  stats: {
+    attack: 8,
+    defense: 10,
+    health: 120,
+  },
+  health: {
+    current: 120,
+    max: 120,
+  },
+};
+
+describe('CombatEngine', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+  });
+
+  it('resolves attack rolls using attack and defense values', () => {
+    const engine = new CombatEngine({ random: () => 0.1 });
+    engine.registerEntity(HERO);
+    engine.registerEntity(BASE_MONSTER);
+
+    const hit = engine.performAttack({
+      attackerId: HERO.id,
+      defenderId: BASE_MONSTER.id,
+      damageType: 'physical',
+      baseDamage: 30,
+    });
+
+    expect(hit.hit).toBe(true);
+    expect(hit.damage).toBeGreaterThan(0);
+    const defenderAfterHit = engine.getEntity(BASE_MONSTER.id);
+    expect(defenderAfterHit?.health.current).toBeLessThan(defenderAfterHit?.health.max);
+
+    const missEngine = new CombatEngine({ random: () => 0.99 });
+    missEngine.registerEntity(HERO);
+    missEngine.registerEntity(BASE_MONSTER);
+    const miss = missEngine.performAttack({
+      attackerId: HERO.id,
+      defenderId: BASE_MONSTER.id,
+      damageType: 'physical',
+      baseDamage: 30,
+    });
+
+    expect(miss.hit).toBe(false);
+    expect(miss.kind).toBe('miss');
+    const defenderAfterMiss = missEngine.getEntity(BASE_MONSTER.id);
+    expect(defenderAfterMiss?.health.current).toBe(defenderAfterMiss?.health.max);
+  });
+
+  it('applies resistance and weakness mitigation per damage type', () => {
+    const neutralEngine = new CombatEngine({ random: () => 0.1 });
+    neutralEngine.registerEntity(HERO);
+    neutralEngine.registerEntity({ ...BASE_MONSTER, id: 'neutral-dummy' });
+    const neutral = neutralEngine.performAttack({
+      attackerId: HERO.id,
+      defenderId: 'neutral-dummy',
+      damageType: 'fire',
+      baseDamage: 40,
+    }).damage;
+
+    const resistedEngine = new CombatEngine({ random: () => 0.1 });
+    resistedEngine.registerEntity(HERO);
+    resistedEngine.registerEntity({
+      ...BASE_MONSTER,
+      id: 'resisted-dummy',
+      resistances: { fire: 0.5 },
+    });
+    const resisted = resistedEngine.performAttack({
+      attackerId: HERO.id,
+      defenderId: 'resisted-dummy',
+      damageType: 'fire',
+      baseDamage: 40,
+    }).damage;
+
+    const weakEngine = new CombatEngine({ random: () => 0.1 });
+    weakEngine.registerEntity(HERO);
+    weakEngine.registerEntity({
+      ...BASE_MONSTER,
+      id: 'weak-dummy',
+      resistances: { fire: -0.25 },
+    });
+    const weak = weakEngine.performAttack({
+      attackerId: HERO.id,
+      defenderId: 'weak-dummy',
+      damageType: 'fire',
+      baseDamage: 40,
+    }).damage;
+
+    const templatedEngine = new CombatEngine({ random: () => 0.1 });
+    templatedEngine.registerEntity(HERO);
+    templatedEngine.registerEntity({
+      ...BASE_MONSTER,
+      id: 'templated-dummy',
+      resistances: ['fire'],
+    });
+    const templated = templatedEngine.performAttack({
+      attackerId: HERO.id,
+      defenderId: 'templated-dummy',
+      damageType: 'fire',
+      baseDamage: 40,
+    }).damage;
+
+    expect(resisted).toBeLessThan(neutral);
+    expect(weak).toBeGreaterThan(neutral);
+    expect(templated).toBeLessThan(neutral);
+    expect(Math.abs(weak - resisted)).toBeGreaterThan(0);
+  });
+
+  it('ticks damage over time effects and clears them when expired', () => {
+    const engine = new CombatEngine({ random: () => 0.1 });
+    engine.registerEntity(HERO);
+    engine.registerEntity({ ...BASE_MONSTER, id: 'dot-target' });
+
+    engine.applyEffect({
+      effect: {
+        id: 'burning-ember',
+        type: 'damage',
+        magnitude: 6,
+        duration: 3000,
+        damageType: 'fire',
+        tickInterval: 1000,
+      },
+      sourceId: HERO.id,
+      targetId: 'dot-target',
+      stacking: 'refresh',
+    });
+
+    const beforeTicks = engine.getEntity('dot-target');
+    expect(beforeTicks?.health.current).toBe(120);
+
+    engine.advanceTime(1000);
+    const afterFirstTick = engine.getEntity('dot-target');
+    expect(afterFirstTick?.health.current).toBeLessThan(120);
+
+    engine.advanceTime(2000);
+    const afterExpiry = engine.getEntity('dot-target');
+    expect(afterExpiry?.health.current).toBeLessThan(afterFirstTick?.health.current);
+    expect(engine.listActiveEffects('dot-target')).toHaveLength(0);
+  });
+
+  it('supports stacking damage over time effects up to the defined cap', () => {
+    const engine = new CombatEngine({ random: () => 0.1 });
+    engine.registerEntity(HERO);
+    engine.registerEntity({ ...BASE_MONSTER, id: 'stack-target' });
+
+    const effect = {
+      id: 'poison-sting',
+      type: 'damage',
+      magnitude: 5,
+      duration: 4000,
+      damageType: 'poison',
+      tickInterval: 1000,
+    };
+
+    engine.applyEffect({ effect, sourceId: HERO.id, targetId: 'stack-target', stacking: 'stack', maxStacks: 3 });
+    engine.advanceTime(1000);
+    const afterFirstTick = engine.getEntity('stack-target');
+
+    engine.applyEffect({ effect, sourceId: HERO.id, targetId: 'stack-target', stacking: 'stack', maxStacks: 3 });
+    engine.advanceTime(1000);
+    const afterSecondTick = engine.getEntity('stack-target');
+
+    engine.applyEffect({ effect, sourceId: HERO.id, targetId: 'stack-target', stacking: 'stack', maxStacks: 3 });
+    engine.advanceTime(1000);
+    const afterThirdTick = engine.getEntity('stack-target');
+
+    expect(afterSecondTick?.health.current).toBeLessThan(afterFirstTick?.health.current);
+    expect(afterThirdTick?.health.current).toBeLessThan(afterSecondTick?.health.current);
+    expect(engine.listActiveEffects('stack-target')[0]?.stacks).toBeLessThanOrEqual(3);
+  });
+
+  it('publishes combat events that update the combat store', () => {
+    const pinia = createPinia();
+    setActivePinia(pinia);
+    const store = useCombatStore();
+    store.ensureSubscriptions();
+
+    const engine = new CombatEngine({ random: () => 0.1 });
+    engine.registerEntity(HERO);
+    engine.registerEntity({ ...BASE_MONSTER, id: 'store-target' });
+
+    const result = engine.performAttack({
+      attackerId: HERO.id,
+      defenderId: 'store-target',
+      damageType: 'physical',
+      baseDamage: 28,
+    });
+
+    expect(result.hit).toBe(true);
+    expect(store.log.length).toBeGreaterThan(0);
+    expect(store.entities['store-target']).toBeDefined();
+    expect(store.entities['store-target'].health.current).toBe(
+      engine.getEntity('store-target')?.health.current,
+    );
+
+    store.dispose();
+  });
+});

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -20,7 +20,7 @@ const resolveEnvironment = () => {
 export default mergeConfig(viteConfig, defineConfig({
   test: {
     environment: resolveEnvironment(),
-    include: ['tests/unit/**/*.spec.js', 'tests/server/**/*.spec.js'],
+    include: ['tests/unit/**/*.spec.{js,ts}', 'tests/server/**/*.spec.js'],
     globals: true,
     setupFiles: ['./tests/unit/setup.js'],
     environmentMatchGlobs: [


### PR DESCRIPTION
## Summary
- add a CombatEngine with hit calculation, mitigation, and effect lifecycle management
- expose a combat Pinia store that reacts to combat events for UI updates
- support TypeScript unit tests and cover combat interactions including DoTs and stacking

## Testing
- npm run test:unit

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e70702e68832192e15ad28d642a44)