### PR TITLE
Add configurable input mapping and ability gating

### DIFF
--- a/src/core/config/controls.js
+++ b/src/core/config/controls.js
@@ -1,58 +1,32 @@
+import { DEFAULT_INPUT_LAYOUTS, normaliseInputLayout } from '../input/input-layout.js';
+
+const DEFAULT_LAYOUT = normaliseInputLayout(DEFAULT_INPUT_LAYOUTS['keyboard-wasd-mouse']);
+
 export const MOVEMENT_BINDINGS = {
-  up: ['w', 'arrowup'],
-  down: ['s', 'arrowdown'],
-  left: ['a', 'arrowleft'],
-  right: ['d', 'arrowright'],
+  up: [...DEFAULT_LAYOUT.movement.up],
+  down: [...DEFAULT_LAYOUT.movement.down],
+  left: [...DEFAULT_LAYOUT.movement.left],
+  right: [...DEFAULT_LAYOUT.movement.right],
 };
 
-export const DIAGONAL_BINDINGS = [
-  ['up', 'right', 'up-right'],
-  ['down', 'right', 'down-right'],
-  ['up', 'left', 'up-left'],
-  ['down', 'left', 'down-left'],
-];
+export const DIAGONAL_BINDINGS = DEFAULT_LAYOUT.diagonals.map((entry) => [...entry]);
 
-export const SKILL_BINDINGS = [
-  {
-    id: 'primary-attack',
-    keys: [' '],
-    type: 'press',
-  },
-  {
-    id: 'dash',
-    keys: ['shift'],
-    type: 'press',
-  },
-  {
-    id: 'ability-1',
-    keys: ['q'],
-    type: 'press',
-  },
-  {
-    id: 'ability-2',
-    keys: ['e'],
-    type: 'press',
-  },
-  {
-    id: 'ability-3',
-    keys: ['r'],
-    type: 'press',
-  },
-  {
-    id: 'ability-4',
-    keys: ['f'],
-    type: 'press',
-  },
-];
+export const SKILL_BINDINGS = DEFAULT_LAYOUT.actions
+  .filter((action) => action.actionType === 'ability')
+  .map((action) => ({
+    id: action.abilityId || action.id,
+    keys: [...(action.inputs.keys || [])],
+    type: action.trigger,
+  }));
 
-export const MOVEMENT_REPEAT = {
-  initialDelayMs: 150,
-  repeatDelayMs: 110,
-};
+export const MOVEMENT_REPEAT = { ...DEFAULT_LAYOUT.repeat };
+
+export const DEFAULT_INPUT_SCHEMES = DEFAULT_INPUT_LAYOUTS;
 
 export default {
   MOVEMENT_BINDINGS,
   DIAGONAL_BINDINGS,
   SKILL_BINDINGS,
   MOVEMENT_REPEAT,
+  DEFAULT_INPUT_SCHEMES,
 };

--- a/src/core/input/input-layout.js
+++ b/src/core/input/input-layout.js
@@ -1,0 +1,391 @@
+const NORMALISED_SPECIAL_KEYS = {
+  space: ' ',
+  spacebar: ' ',
+};
+
+export const normaliseInputKey = (rawKey) => {
+  if (rawKey === null || rawKey === undefined) {
+    return '';
+  }
+
+  if (typeof rawKey === 'number') {
+    return String(rawKey);
+  }
+
+  const stringKey = `${rawKey}`;
+  if (stringKey === ' ') {
+    return ' ';
+  }
+
+  const lower = stringKey.toLowerCase();
+  if (Object.prototype.hasOwnProperty.call(NORMALISED_SPECIAL_KEYS, lower)) {
+    return NORMALISED_SPECIAL_KEYS[lower];
+  }
+
+  return lower;
+};
+
+const normaliseMovementKeys = (keys) => {
+  if (!Array.isArray(keys)) {
+    return [];
+  }
+
+  const seen = new Set();
+  keys.forEach((key) => {
+    const normalised = normaliseInputKey(key);
+    if (normalised) {
+      seen.add(normalised);
+    }
+  });
+  return [...seen];
+};
+
+const normaliseDiagonalEntry = (entry) => {
+  if (Array.isArray(entry) && entry.length >= 3) {
+    const [vertical, horizontal, diagonal] = entry;
+    if (vertical && horizontal && diagonal) {
+      return [String(vertical), String(horizontal), String(diagonal)];
+    }
+    return null;
+  }
+
+  if (entry && typeof entry === 'object') {
+    const vertical = entry.vertical || entry.up;
+    const horizontal = entry.horizontal || entry.right;
+    const diagonal = entry.direction || entry.diagonal;
+    if (vertical && horizontal && diagonal) {
+      return [String(vertical), String(horizontal), String(diagonal)];
+    }
+  }
+
+  return null;
+};
+
+const normaliseRepeat = (repeat = {}) => {
+  const initialDelay = Number(repeat.initialDelayMs ?? repeat.initial ?? 150);
+  const repeatDelay = Number(repeat.repeatDelayMs ?? repeat.repeat ?? 110);
+
+  return {
+    initialDelayMs: Number.isFinite(initialDelay) && initialDelay >= 0 ? initialDelay : 150,
+    repeatDelayMs: Number.isFinite(repeatDelay) && repeatDelay >= 0 ? repeatDelay : 110,
+  };
+};
+
+const normaliseAnalogEntry = (entry) => {
+  if (!entry || typeof entry !== 'object') {
+    return null;
+  }
+
+  const id = typeof entry.id === 'string' && entry.id ? entry.id : 'left';
+  const controls = typeof entry.controls === 'string' ? entry.controls : 'movement';
+  const deadzoneValue = Number(entry.deadzone);
+  const deadzone = Number.isFinite(deadzoneValue) && deadzoneValue >= 0 ? Math.min(deadzoneValue, 0.99) : 0.3;
+
+  return {
+    id,
+    controls,
+    deadzone,
+  };
+};
+
+const createActionId = (action, fallbackIndex) => {
+  if (typeof action.id === 'string' && action.id) {
+    return action.id;
+  }
+  if (typeof action.abilityId === 'string' && action.abilityId) {
+    return action.abilityId;
+  }
+  if (typeof action.actionId === 'string' && action.actionId) {
+    return action.actionId;
+  }
+  return `action-${fallbackIndex}`;
+};
+
+const normaliseActionBinding = (action, index) => {
+  if (!action || typeof action !== 'object') {
+    return null;
+  }
+
+  const triggerRaw = action.trigger || action.type || 'press';
+  const trigger = ['hold', 'toggle'].includes(triggerRaw) ? triggerRaw : 'press';
+  const actionType = action.actionType || action.category || action.kind || (action.abilityId || action.ability)
+    ? 'ability'
+    : (action.actionId || action.id)
+      ? 'action'
+      : 'ability';
+
+  const inputs = action.inputs && typeof action.inputs === 'object' ? action.inputs : {};
+  const keyInputs = Array.isArray(inputs.keys) ? inputs.keys : action.keys;
+  const buttonInputs = Array.isArray(inputs.buttons) ? inputs.buttons : action.buttons;
+
+  const normalisedKeys = normaliseMovementKeys(keyInputs);
+  const normalisedButtons = Array.isArray(buttonInputs)
+    ? [...new Set(buttonInputs.map((button) => (button === null || button === undefined)
+      ? ''
+      : `${button}`.toLowerCase()).filter(Boolean))]
+    : [];
+
+  const abilityId = action.abilityId
+    || action.ability
+    || (actionType === 'ability' && typeof action.id === 'string' ? action.id : null);
+  const actionId = action.actionId || (actionType === 'action' ? action.id : null);
+
+  return {
+    id: createActionId(action, index),
+    label: typeof action.label === 'string' ? action.label : null,
+    description: typeof action.description === 'string' ? action.description : null,
+    trigger,
+    actionType: actionType === 'action' ? 'action' : 'ability',
+    abilityId: actionType === 'ability' ? abilityId || actionId : null,
+    actionId: actionType === 'action' ? actionId || abilityId : null,
+    inputs: {
+      keys: normalisedKeys,
+      buttons: normalisedButtons,
+    },
+  };
+};
+
+const clone = (value) => JSON.parse(JSON.stringify(value));
+
+const composeLayouts = (base, override) => {
+  if (!override || typeof override !== 'object') {
+    return clone(base);
+  }
+
+  const composed = clone(base);
+
+  if (override.id) {
+    composed.id = override.id;
+  }
+
+  if (override.label) {
+    composed.label = override.label;
+  }
+
+  if (override.movement && typeof override.movement === 'object') {
+    composed.movement = {
+      ...composed.movement,
+      ...Object.entries(override.movement).reduce((acc, [direction, keys]) => {
+        acc[direction] = Array.isArray(keys) ? [...keys] : keys;
+        return acc;
+      }, {}),
+    };
+  }
+
+  if (Array.isArray(override.diagonals) && override.diagonals.length) {
+    composed.diagonals = [...override.diagonals];
+  }
+
+  const repeatOverride = override.repeat || override.movementRepeat;
+  if (repeatOverride && typeof repeatOverride === 'object') {
+    composed.repeat = {
+      ...composed.repeat,
+      ...repeatOverride,
+    };
+  }
+
+  if (Array.isArray(override.actions) && override.actions.length) {
+    composed.actions = [...override.actions];
+  }
+
+  if (Array.isArray(override.analogs)) {
+    composed.analogs = [...override.analogs];
+  }
+
+  return composed;
+};
+
+export const DEFAULT_INPUT_LAYOUTS = {
+  'keyboard-wasd-mouse': {
+    id: 'keyboard-wasd-mouse',
+    label: 'Keyboard — WASD & Mouse',
+    movement: {
+      up: ['w', 'arrowup'],
+      down: ['s', 'arrowdown'],
+      left: ['a', 'arrowleft'],
+      right: ['d', 'arrowright'],
+    },
+    diagonals: [
+      ['up', 'right', 'up-right'],
+      ['down', 'right', 'down-right'],
+      ['up', 'left', 'up-left'],
+      ['down', 'left', 'down-left'],
+    ],
+    repeat: {
+      initialDelayMs: 150,
+      repeatDelayMs: 110,
+    },
+    actions: [
+      {
+        id: 'primary-attack',
+        abilityId: 'primary-attack',
+        trigger: 'press',
+        inputs: { keys: [' '] },
+      },
+      {
+        id: 'dash',
+        abilityId: 'dash',
+        trigger: 'press',
+        inputs: { keys: ['shift'] },
+      },
+      {
+        id: 'ability-1',
+        abilityId: 'ability-1',
+        trigger: 'press',
+        inputs: { keys: ['q'] },
+      },
+      {
+        id: 'ability-2',
+        abilityId: 'ability-2',
+        trigger: 'press',
+        inputs: { keys: ['e'] },
+      },
+      {
+        id: 'ability-3',
+        abilityId: 'ability-3',
+        trigger: 'press',
+        inputs: { keys: ['r'] },
+      },
+      {
+        id: 'ability-4',
+        abilityId: 'ability-4',
+        trigger: 'press',
+        inputs: { keys: ['f'] },
+      },
+    ],
+    analogs: [
+      { id: 'left', controls: 'movement', deadzone: 0.3 },
+    ],
+  },
+  'controller-standard': {
+    id: 'controller-standard',
+    label: 'Controller — Standard',
+    movement: {
+      up: ['dpadup'],
+      down: ['dpaddown'],
+      left: ['dpadleft'],
+      right: ['dpadright'],
+    },
+    diagonals: [
+      ['up', 'right', 'up-right'],
+      ['down', 'right', 'down-right'],
+      ['up', 'left', 'up-left'],
+      ['down', 'left', 'down-left'],
+    ],
+    repeat: {
+      initialDelayMs: 120,
+      repeatDelayMs: 120,
+    },
+    actions: [
+      {
+        id: 'primary-attack',
+        abilityId: 'primary-attack',
+        trigger: 'press',
+        inputs: { buttons: ['button0'] },
+      },
+      {
+        id: 'dash',
+        abilityId: 'dash',
+        trigger: 'press',
+        inputs: { buttons: ['button1'] },
+      },
+      {
+        id: 'ability-1',
+        abilityId: 'ability-1',
+        trigger: 'press',
+        inputs: { buttons: ['button4'] },
+      },
+      {
+        id: 'ability-2',
+        abilityId: 'ability-2',
+        trigger: 'press',
+        inputs: { buttons: ['button5'] },
+      },
+      {
+        id: 'ability-3',
+        abilityId: 'ability-3',
+        trigger: 'press',
+        inputs: { buttons: ['button2'] },
+      },
+      {
+        id: 'ability-4',
+        abilityId: 'ability-4',
+        trigger: 'press',
+        inputs: { buttons: ['button3'] },
+      },
+    ],
+    analogs: [
+      { id: 'left', controls: 'movement', deadzone: 0.25 },
+    ],
+  },
+};
+
+export const parseInputLayout = (source) => {
+  if (!source) {
+    return null;
+  }
+
+  if (typeof source === 'string') {
+    try {
+      const parsed = JSON.parse(source);
+      return parsed && typeof parsed === 'object' ? parsed : null;
+    } catch (error) {
+      return null;
+    }
+  }
+
+  if (typeof source === 'object') {
+    return clone(source);
+  }
+
+  return null;
+};
+
+export const normaliseInputLayout = (layout = {}, fallbackId = 'keyboard-wasd-mouse') => {
+  const baseLayout = DEFAULT_INPUT_LAYOUTS[fallbackId] || DEFAULT_INPUT_LAYOUTS['keyboard-wasd-mouse'];
+  const composed = composeLayouts(baseLayout, layout);
+
+  const movement = composed.movement || {};
+  const diagonals = Array.isArray(composed.diagonals) ? composed.diagonals : [];
+  const actions = Array.isArray(composed.actions) ? composed.actions : [];
+  const analogs = Array.isArray(composed.analogs) ? composed.analogs : [];
+
+  const normalisedMovement = {
+    up: normaliseMovementKeys(movement.up || baseLayout.movement.up),
+    down: normaliseMovementKeys(movement.down || baseLayout.movement.down),
+    left: normaliseMovementKeys(movement.left || baseLayout.movement.left),
+    right: normaliseMovementKeys(movement.right || baseLayout.movement.right),
+  };
+
+  const normalisedDiagonals = diagonals
+    .map((entry) => normaliseDiagonalEntry(entry))
+    .filter((entry) => entry && entry.every((value) => typeof value === 'string'));
+
+  const normalisedActions = actions
+    .map((action, index) => normaliseActionBinding(action, index))
+    .filter((binding) => binding && (binding.inputs.keys.length || binding.inputs.buttons.length));
+
+  const normalisedAnalogs = analogs
+    .map((entry) => normaliseAnalogEntry(entry))
+    .filter(Boolean);
+
+  return {
+    id: typeof composed.id === 'string' ? composed.id : baseLayout.id,
+    label: typeof composed.label === 'string' ? composed.label : baseLayout.label,
+    movement: normalisedMovement,
+    diagonals: normalisedDiagonals.length ? normalisedDiagonals : [...baseLayout.diagonals],
+    repeat: normaliseRepeat(composed.repeat || {}),
+    actions: normalisedActions.length ? normalisedActions : baseLayout.actions.map((action, index) => normaliseActionBinding(action, index)).filter(Boolean),
+    analogs: normalisedAnalogs,
+  };
+};
+
+export const cloneInputLayout = (layout) => clone(layout);
+
+export default {
+  DEFAULT_INPUT_LAYOUTS,
+  parseInputLayout,
+  normaliseInputLayout,
+  cloneInputLayout,
+  normaliseInputKey,
+};

--- a/src/core/input/input-mapper.js
+++ b/src/core/input/input-mapper.js
@@ -1,0 +1,370 @@
+import {
+  DEFAULT_INPUT_LAYOUTS,
+  normaliseInputLayout,
+  normaliseInputKey,
+  parseInputLayout,
+} from './input-layout.js';
+
+const DEFAULT_LAYOUT_ID = 'keyboard-wasd-mouse';
+
+const normaliseButtonId = (rawButton) => {
+  if (rawButton === null || rawButton === undefined) {
+    return '';
+  }
+  return `${rawButton}`.toLowerCase();
+};
+
+const setsEqual = (a, b) => {
+  if (a.size !== b.size) {
+    return false;
+  }
+  for (const value of a) {
+    if (!b.has(value)) {
+      return false;
+    }
+  }
+  return true;
+};
+
+const clone = (value) => JSON.parse(JSON.stringify(value));
+
+class InputMapper {
+  constructor(layout = null) {
+    this.layoutId = DEFAULT_LAYOUT_ID;
+    this.layout = normaliseInputLayout(DEFAULT_INPUT_LAYOUTS[DEFAULT_LAYOUT_ID], DEFAULT_LAYOUT_ID);
+    this.keyBindings = new Map();
+    this.buttonBindings = new Map();
+    this.bindingState = new Map();
+    this.movementBindings = clone(this.layout.movement);
+    this.diagonalBindings = [...this.layout.diagonals];
+    this.movementRepeat = { ...this.layout.repeat };
+    this.activeMovementKeys = new Set();
+    this.stickDirections = new Map();
+    this.analogDirections = new Set();
+    this.lastDirection = null;
+    this.analogConfig = Array.isArray(this.layout.analogs) ? [...this.layout.analogs] : [];
+
+    this.applyLayout(layout || DEFAULT_INPUT_LAYOUTS[DEFAULT_LAYOUT_ID]);
+  }
+
+  applyLayout(layoutDescriptor) {
+    const parsed = parseInputLayout(layoutDescriptor);
+    const layoutId = parsed && typeof parsed.id === 'string' ? parsed.id : DEFAULT_LAYOUT_ID;
+    const fallback = DEFAULT_INPUT_LAYOUTS[layoutId] ? layoutId : DEFAULT_LAYOUT_ID;
+    this.layout = normaliseInputLayout(parsed || DEFAULT_INPUT_LAYOUTS[fallback], fallback);
+    this.layoutId = this.layout.id || fallback;
+
+    this.rebuildBindings();
+    this.resetState();
+  }
+
+  rebuildBindings() {
+    this.keyBindings.clear();
+    this.buttonBindings.clear();
+    this.bindingState.clear();
+    this.movementBindings = clone(this.layout.movement);
+    this.diagonalBindings = [...this.layout.diagonals];
+    this.movementRepeat = { ...this.layout.repeat };
+    this.analogConfig = Array.isArray(this.layout.analogs) ? [...this.layout.analogs] : [];
+
+    this.layout.actions.forEach((action, index) => {
+      const bindingKey = `${action.actionType}:${action.id}:${index}`;
+      const state = new Set();
+      this.bindingState.set(bindingKey, state);
+
+      const descriptor = {
+        ...action,
+        bindingKey,
+      };
+
+      (action.inputs.keys || []).forEach((key) => {
+        const normalisedKey = normaliseInputKey(key);
+        if (!normalisedKey) {
+          return;
+        }
+        const list = this.keyBindings.get(normalisedKey) || [];
+        list.push({ ...descriptor, source: 'keyboard' });
+        this.keyBindings.set(normalisedKey, list);
+      });
+
+      (action.inputs.buttons || []).forEach((button) => {
+        const buttonId = normaliseButtonId(button);
+        if (!buttonId) {
+          return;
+        }
+        const list = this.buttonBindings.get(buttonId) || [];
+        list.push({ ...descriptor, source: 'gamepad' });
+        this.buttonBindings.set(buttonId, list);
+      });
+    });
+  }
+
+  resetState() {
+    this.activeMovementKeys.clear();
+    this.stickDirections.clear();
+    this.analogDirections.clear();
+    this.lastDirection = null;
+    this.bindingState.forEach((state) => state.clear());
+  }
+
+  destroy() {
+    this.resetState();
+  }
+
+  getMovementRepeat() {
+    return { ...this.movementRepeat };
+  }
+
+  handleKeyboardEvent(eventType, rawKey, options = {}) {
+    const key = normaliseInputKey(rawKey);
+    if (!key) {
+      return null;
+    }
+
+    const actions = [];
+    let movementChanged = false;
+
+    if (eventType === 'down') {
+      this.activeMovementKeys.add(key);
+      const bindings = this.keyBindings.get(key) || [];
+      actions.push(...this.triggerBindings(bindings, 'down', {
+        inputId: key,
+        repeat: Boolean(options.repeat),
+      }));
+    } else if (eventType === 'up') {
+      this.activeMovementKeys.delete(key);
+      const bindings = this.keyBindings.get(key) || [];
+      actions.push(...this.triggerBindings(bindings, 'up', {
+        inputId: key,
+        repeat: Boolean(options.repeat),
+      }));
+    }
+
+    const direction = this.computeMovementDirection();
+    if (direction !== this.lastDirection) {
+      movementChanged = true;
+      this.lastDirection = direction;
+    }
+
+    return {
+      handled: actions.length > 0 || movementChanged,
+      actions,
+      movementDirection: direction,
+      movementChanged,
+      movementSource: 'keyboard',
+      eventType,
+    };
+  }
+
+  handleButtonEvent(eventType, rawButton, options = {}) {
+    const button = normaliseButtonId(rawButton);
+    if (!button) {
+      return null;
+    }
+
+    const bindings = this.buttonBindings.get(button) || [];
+    const actions = this.triggerBindings(bindings, eventType === 'down' ? 'down' : 'up', {
+      inputId: button,
+      repeat: Boolean(options.repeat),
+    });
+
+    return {
+      handled: actions.length > 0,
+      actions,
+      movementDirection: this.lastDirection,
+      movementChanged: false,
+      movementSource: 'gamepad',
+      eventType,
+    };
+  }
+
+  handleAnalogEvent(vector = {}, options = {}) {
+    const id = typeof options.id === 'string' && options.id ? options.id : 'left';
+    const config = this.analogConfig.find((entry) => entry.id === id && entry.controls === 'movement');
+    if (!config) {
+      return {
+        handled: false,
+        actions: [],
+        movementDirection: this.lastDirection,
+        movementChanged: false,
+        movementSource: 'analog',
+        eventType: 'analog',
+      };
+    }
+
+    const deadzone = Number.isFinite(options.deadzone) ? Math.max(0, Math.min(options.deadzone, 0.99)) : config.deadzone;
+    const x = Number.isFinite(vector.x) ? vector.x : 0;
+    const y = Number.isFinite(vector.y) ? vector.y : 0;
+
+    const directions = new Set();
+    if (y < -deadzone) {
+      directions.add('up');
+    } else if (y > deadzone) {
+      directions.add('down');
+    }
+
+    if (x < -deadzone) {
+      directions.add('left');
+    } else if (x > deadzone) {
+      directions.add('right');
+    }
+
+    const existing = this.stickDirections.get(id) || new Set();
+    if (!setsEqual(existing, directions)) {
+      this.stickDirections.set(id, directions);
+      this.refreshAnalogDirections();
+      const direction = this.computeMovementDirection();
+      const movementChanged = direction !== this.lastDirection;
+      if (movementChanged) {
+        this.lastDirection = direction;
+      }
+
+      return {
+        handled: movementChanged,
+        actions: [],
+        movementDirection: direction,
+        movementChanged,
+        movementSource: 'analog',
+        eventType: 'analog',
+      };
+    }
+
+    return {
+      handled: false,
+      actions: [],
+      movementDirection: this.lastDirection,
+      movementChanged: false,
+      movementSource: 'analog',
+      eventType: 'analog',
+    };
+  }
+
+  refreshAnalogDirections() {
+    const aggregate = new Set();
+    this.stickDirections.forEach((directions) => {
+      directions.forEach((direction) => aggregate.add(direction));
+    });
+    this.analogDirections = aggregate;
+  }
+
+  triggerBindings(bindings, phase, context = {}) {
+    if (!Array.isArray(bindings) || !bindings.length) {
+      return [];
+    }
+
+    const actions = [];
+
+    bindings.forEach((binding) => {
+      const state = this.bindingState.get(binding.bindingKey);
+      if (!state) {
+        return;
+      }
+
+      const inputId = context.inputId || binding.id;
+
+      if (phase === 'down') {
+        if (binding.trigger === 'press') {
+          if (context.repeat || state.has(inputId)) {
+            return;
+          }
+          state.add(inputId);
+          actions.push(this.createAction(binding, 'start', inputId, context));
+          return;
+        }
+
+        if (binding.trigger === 'hold') {
+          if (state.has(inputId)) {
+            return;
+          }
+          state.add(inputId);
+          actions.push(this.createAction(binding, 'start', inputId, context));
+          return;
+        }
+
+        if (binding.trigger === 'toggle') {
+          const active = state.has('toggle');
+          state.clear();
+          if (!active) {
+            state.add('toggle');
+            actions.push(this.createAction(binding, 'start', inputId, context));
+          } else {
+            actions.push(this.createAction(binding, 'end', inputId, context));
+          }
+        }
+
+        return;
+      }
+
+      if (binding.trigger === 'hold' && state.has(inputId)) {
+        state.delete(inputId);
+        actions.push(this.createAction(binding, 'end', inputId, context));
+      } else if (binding.trigger === 'press' && state.has(inputId)) {
+        state.delete(inputId);
+      }
+    });
+
+    return actions;
+  }
+
+  createAction(binding, phase, inputId, context = {}) {
+    const payload = {
+      type: binding.actionType,
+      abilityId: binding.abilityId || null,
+      actionId: binding.actionId || null,
+      trigger: binding.trigger,
+      phase,
+      source: binding.source,
+      inputId,
+      repeat: Boolean(context.repeat),
+      bindingId: binding.bindingKey,
+      label: binding.label || null,
+    };
+
+    return payload;
+  }
+
+  computeMovementDirection() {
+    const hasDirection = (direction) => {
+      const keys = this.movementBindings[direction] || [];
+      const keyboardActive = keys.some((key) => this.activeMovementKeys.has(key));
+      if (keyboardActive) {
+        return true;
+      }
+      return this.analogDirections.has(direction);
+    };
+
+    const up = hasDirection('up');
+    const down = hasDirection('down');
+    const left = hasDirection('left');
+    const right = hasDirection('right');
+
+    if ((up && down) || (left && right)) {
+      return null;
+    }
+
+    for (let i = 0; i < this.diagonalBindings.length; i += 1) {
+      const [vertical, horizontal, diagonal] = this.diagonalBindings[i];
+      if (vertical === 'up' && horizontal === 'right' && up && right) {
+        return diagonal;
+      }
+      if (vertical === 'down' && horizontal === 'right' && down && right) {
+        return diagonal;
+      }
+      if (vertical === 'up' && horizontal === 'left' && up && left) {
+        return diagonal;
+      }
+      if (vertical === 'down' && horizontal === 'left' && down && left) {
+        return diagonal;
+      }
+    }
+
+    if (up) return 'up';
+    if (down) return 'down';
+    if (left) return 'left';
+    if (right) return 'right';
+
+    return null;
+  }
+}
+
+export default InputMapper;


### PR DESCRIPTION
## Summary
- add reusable input layout definitions and mapping utilities for keyboard and controller bindings
- update the input controller and game canvas to load configurable layouts and translate events into ability actions
- extend the ability manager to validate and queue abilities with skill-definition fallbacks before notifying the server

## Testing
- npm run test:unit

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e7d6578048321bd2020217ad1fac2)