### PR TITLE
Add reactive combat HUD components and FX cues

### DIFF
--- a/src/components/combat/CombatCooldownWheel.vue
+++ b/src/components/combat/CombatCooldownWheel.vue
@@ -1,0 +1,223 @@
+<template>
+  <div class="combat-cooldown-wheel" :class="wheelClasses">
+    <svg class="combat-cooldown-wheel__svg" viewBox="0 0 36 36">
+      <circle
+        class="combat-cooldown-wheel__bg"
+        cx="18"
+        cy="18"
+        r="16"
+      />
+      <circle
+        class="combat-cooldown-wheel__progress"
+        cx="18"
+        cy="18"
+        r="16"
+        :stroke-dasharray="dashArray"
+        :stroke-dashoffset="dashOffset"
+      />
+    </svg>
+    <div class="combat-cooldown-wheel__content">
+      <slot name="icon">
+        <span class="combat-cooldown-wheel__label">{{ displayLabel }}</span>
+      </slot>
+      <span v-if="isCoolingDown" class="combat-cooldown-wheel__timer">{{ remainingSeconds }}</span>
+    </div>
+  </div>
+</template>
+
+<script>
+import { mapStores } from 'pinia';
+
+import { useCombatStore } from '@/stores/combat.js';
+import { resolveAbilityCue, getAbilityDefinition } from './fx.js';
+
+const formatSeconds = (ms) => {
+  const seconds = Math.ceil(ms / 1000);
+  return `${seconds}`;
+};
+
+export default {
+  name: 'CombatCooldownWheel',
+  props: {
+    entityId: {
+      type: [String, Number],
+      required: true,
+    },
+    abilityId: {
+      type: String,
+      required: true,
+    },
+    abilityLabel: {
+      type: String,
+      default: '',
+    },
+  },
+  data() {
+    return {
+      subscriptionEnsured: false,
+    };
+  },
+  computed: {
+    ...mapStores(useCombatStore),
+    entity() {
+      return this.combatStore.entities[this.entityId] || null;
+    },
+    abilityCooldown() {
+      if (!this.entity) {
+        return null;
+      }
+
+      const cooldowns = this.entity.cooldowns?.abilities
+        || this.entity.combatState?.cooldowns?.abilities
+        || {};
+
+      const entry = cooldowns[this.abilityId];
+      if (!entry) {
+        return { duration: 0, remaining: 0 };
+      }
+
+      return {
+        duration: Number(entry.duration ?? entry.total ?? 0),
+        remaining: Number(entry.remaining ?? entry.time ?? 0),
+      };
+    },
+    durationMs() {
+      return Math.max(0, this.abilityCooldown?.duration || 0);
+    },
+    remainingMs() {
+      return Math.max(0, Math.min(this.abilityCooldown?.remaining || 0, this.durationMs));
+    },
+    progress() {
+      if (!this.durationMs) {
+        return 0;
+      }
+
+      return Math.max(0, Math.min(1, this.remainingMs / this.durationMs));
+    },
+    dashArray() {
+      const circumference = 2 * Math.PI * 16;
+      return `${circumference}`;
+    },
+    dashOffset() {
+      const circumference = 2 * Math.PI * 16;
+      return `${(1 - this.progress) * circumference}`;
+    },
+    remainingSeconds() {
+      if (!this.remainingMs) {
+        return '';
+      }
+
+      return formatSeconds(this.remainingMs);
+    },
+    isCoolingDown() {
+      return this.remainingMs > 0;
+    },
+    wheelCue() {
+      return resolveAbilityCue(this.abilityId);
+    },
+    wheelClasses() {
+      return ['combat-cooldown-wheel--active', this.wheelCue.className];
+    },
+    displayLabel() {
+      if (this.abilityLabel) {
+        return this.abilityLabel;
+      }
+
+      const ability = getAbilityDefinition(this.abilityId);
+      return ability?.name || this.abilityId;
+    },
+  },
+  watch: {
+    combatStore: {
+      handler() {
+        this.ensureSubscription();
+      },
+      immediate: true,
+    },
+  },
+  mounted() {
+    this.ensureSubscription();
+  },
+  methods: {
+    ensureSubscription() {
+      if (this.subscriptionEnsured) {
+        return;
+      }
+
+      if (this.combatStore && typeof this.combatStore.ensureSubscriptions === 'function') {
+        this.combatStore.ensureSubscriptions();
+        this.subscriptionEnsured = true;
+      }
+    },
+  },
+};
+</script>
+
+<style scoped lang="scss">
+@use '@/assets/scss/abstracts/tokens' as *;
+
+.combat-cooldown-wheel {
+  position: relative;
+  display: inline-grid;
+  place-items: center;
+  width: var(--size, 56px);
+  height: var(--size, 56px);
+  color: var(--surface-text-strong);
+}
+
+.combat-cooldown-wheel__svg {
+  width: 100%;
+  height: 100%;
+  transform: rotate(-90deg);
+}
+
+.combat-cooldown-wheel__bg {
+  fill: none;
+  stroke: rgba(255, 255, 255, 0.15);
+  stroke-width: 3;
+}
+
+.combat-cooldown-wheel__progress {
+  fill: none;
+  stroke: rgba(255, 255, 255, 0.85);
+  stroke-width: 3;
+  stroke-linecap: round;
+  transition: stroke-dashoffset 140ms ease-out;
+}
+
+.combat-cooldown-wheel__content {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  gap: var(--space-4xs);
+  pointer-events: none;
+}
+
+.combat-cooldown-wheel__label {
+  font-size: var(--font-size-2xs);
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+}
+
+.combat-cooldown-wheel__timer {
+  font-size: var(--font-size-xs);
+  font-variant-numeric: tabular-nums;
+}
+
+.combat-cooldown-wheel--active.is-active .combat-cooldown-wheel__progress {
+  stroke: rgba(80, 200, 255, 0.9);
+}
+
+.combat-cooldown-wheel--active.is-passive .combat-cooldown-wheel__progress {
+  stroke: rgba(200, 160, 255, 0.9);
+}
+
+.combat-cooldown-wheel--active.is-ultimate .combat-cooldown-wheel__progress {
+  stroke: rgba(255, 160, 80, 0.9);
+}
+
+.combat-cooldown-wheel--active.is-general .combat-cooldown-wheel__progress {
+  stroke: rgba(255, 255, 255, 0.85);
+}
+</style>

--- a/src/components/combat/CombatDamageFloaters.vue
+++ b/src/components/combat/CombatDamageFloaters.vue
@@ -1,0 +1,354 @@
+<template>
+  <div class="combat-damage-floaters">
+    <transition-group name="combat-damage-floater" tag="div">
+      <div
+        v-for="floater in floaters"
+        :key="floater.id"
+        class="combat-damage-floater"
+        :class="floater.classes"
+        :style="floater.style"
+      >
+        <span class="combat-damage-floater__value">{{ floater.value }}</span>
+      </div>
+    </transition-group>
+  </div>
+</template>
+
+<script>
+import { mapStores } from 'pinia';
+
+import { useCombatStore } from '@/stores/combat.js';
+import {
+  resolveDamageCue,
+  resolveEffectMetadata,
+  resolveAbilityCue,
+  resolveAbilityPrimaryDamageType,
+  triggerSoundCue,
+  triggerParticleCue,
+} from './fx.js';
+
+const isPositiveNumber = (value) => Number.isFinite(value) && value !== 0;
+
+export default {
+  name: 'CombatDamageFloaters',
+  props: {
+    entityId: {
+      type: [String, Number],
+      default: null,
+    },
+    lifespanMs: {
+      type: Number,
+      default: 1400,
+    },
+  },
+  data() {
+    return {
+      subscriptionEnsured: false,
+      lastTimestamp: 0,
+      floaters: [],
+      timeouts: new Map(),
+    };
+  },
+  computed: {
+    ...mapStores(useCombatStore),
+  },
+  watch: {
+    'combatStore.log': {
+      handler(log) {
+        this.ensureSubscription();
+        this.processLog(log);
+      },
+      deep: true,
+      immediate: true,
+    },
+    entityId() {
+      this.reset();
+    },
+  },
+  beforeUnmount() {
+    this.reset();
+  },
+  methods: {
+    ensureSubscription() {
+      if (this.subscriptionEnsured) {
+        return;
+      }
+
+      if (this.combatStore && typeof this.combatStore.ensureSubscriptions === 'function') {
+        this.combatStore.ensureSubscriptions();
+        this.subscriptionEnsured = true;
+      }
+    },
+    processLog(log) {
+      if (!Array.isArray(log)) {
+        return;
+      }
+
+      log.forEach((event) => {
+        if (!event) {
+          return;
+        }
+
+        const timestamp = event.timestamp || Date.now();
+        if (timestamp <= this.lastTimestamp) {
+          return;
+        }
+
+        this.handleEvent(event);
+        this.lastTimestamp = Math.max(this.lastTimestamp, timestamp);
+      });
+    },
+    handleEvent(event) {
+      if (!event || !event.kind) {
+        return;
+      }
+
+      if (!this.matchesEntityFilter(event)) {
+        return;
+      }
+
+      switch (event.kind) {
+      case 'damage':
+      case 'effect-damage':
+        this.spawnDamageFloater(event, { damageType: this.resolveDamageType(event) });
+        break;
+      case 'effect-tick':
+        if (event.tickType === 'damage') {
+          this.spawnDamageFloater(event, { damageType: this.resolveDamageType(event) });
+        } else if (event.tickType === 'heal') {
+          this.spawnHealFloater(event);
+        }
+        break;
+      case 'heal':
+      case 'effect-heal':
+        this.spawnHealFloater(event);
+        break;
+      case 'ai-action':
+        if (event.action === 'cast' && event.abilityId) {
+          this.handleAbilityCue(event);
+        }
+        break;
+      case 'attack':
+        if (isPositiveNumber(event.damage)) {
+          this.spawnDamageFloater(
+            { ...event, amount: event.damage },
+            { damageType: event.damageType },
+          );
+        }
+        break;
+      default:
+        break;
+      }
+    },
+    matchesEntityFilter(event) {
+      if (!this.entityId) {
+        return true;
+      }
+
+      const filterId = String(this.entityId);
+      const candidates = [
+        event.targetId,
+        event.sourceId,
+        event.entityId,
+        event.attackerId,
+        event.defenderId,
+      ];
+
+      return candidates.some((candidate) => candidate != null && String(candidate) === filterId);
+    },
+    resolveDamageType(event) {
+      if (event.damageType) {
+        return event.damageType;
+      }
+
+      if (event.effectId) {
+        const metadata = resolveEffectMetadata(event.effectId);
+        if (metadata?.damageType) {
+          return metadata.damageType;
+        }
+
+        if (metadata?.abilityId) {
+          return resolveAbilityPrimaryDamageType(metadata.abilityId);
+        }
+      }
+
+      if (event.abilityId) {
+        return resolveAbilityPrimaryDamageType(event.abilityId);
+      }
+
+      return 'physical';
+    },
+    spawnDamageFloater(event, options = {}) {
+      const amount = Math.abs(Number(event.amount ?? event.damage ?? 0));
+      if (!isPositiveNumber(amount)) {
+        return;
+      }
+
+      const damageType = options.damageType || 'physical';
+      const cue = resolveDamageCue(damageType, 'general');
+      const id = `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+      const floater = {
+        id,
+        value: `-${Math.round(amount)}`,
+        classes: ['combat-damage-floater--damage', cue.className],
+        style: this.generateFloaterStyle(),
+      };
+
+      this.floaters.push(floater);
+      triggerSoundCue(cue.sound);
+      triggerParticleCue({
+        particle: cue.particle,
+        entityId: this.entityId || event.targetId || event.defenderId || null,
+        damageType,
+      });
+      this.scheduleRemoval(id);
+    },
+    spawnHealFloater(event) {
+      const amount = Math.abs(Number(event.amount ?? 0));
+      if (!isPositiveNumber(amount)) {
+        return;
+      }
+
+      const cue = resolveDamageCue('heal', 'heal');
+      const id = `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+      const floater = {
+        id,
+        value: `+${Math.round(amount)}`,
+        classes: ['combat-damage-floater--heal', cue.className],
+        style: this.generateFloaterStyle(),
+      };
+
+      this.floaters.push(floater);
+      triggerSoundCue(cue.sound);
+      triggerParticleCue({
+        particle: cue.particle,
+        entityId: this.entityId || event.targetId || null,
+        damageType: 'heal',
+      });
+      this.scheduleRemoval(id);
+    },
+    handleAbilityCue(event) {
+      const cue = resolveAbilityCue(event.abilityId);
+      triggerSoundCue(cue.sound);
+      triggerParticleCue({
+        particle: cue.particle,
+        entityId: this.entityId || event.sourceId || null,
+        category: cue.category,
+        damageType: this.resolveDamageType(event) || null,
+      });
+    },
+    scheduleRemoval(id) {
+      const timer = setTimeout(() => {
+        this.removeFloater(id);
+      }, this.lifespanMs);
+      this.timeouts.set(id, timer);
+    },
+    removeFloater(id) {
+      this.floaters = this.floaters.filter((floater) => floater.id !== id);
+      const timer = this.timeouts.get(id);
+      if (timer) {
+        clearTimeout(timer);
+        this.timeouts.delete(id);
+      }
+    },
+    clearTimers() {
+      this.timeouts.forEach((timer) => clearTimeout(timer));
+      this.timeouts.clear();
+    },
+    reset() {
+      this.clearTimers();
+      this.floaters = [];
+      this.lastTimestamp = 0;
+    },
+    generateFloaterStyle() {
+      const horizontalOffset = (Math.random() - 0.5) * 40;
+      const verticalOffset = Math.random() * -20;
+      return {
+        '--floater-translate-x': `${horizontalOffset.toFixed(2)}px`,
+        '--floater-translate-y': `${verticalOffset.toFixed(2)}px`,
+      };
+    },
+  },
+};
+</script>
+
+<style scoped lang="scss">
+@use '@/assets/scss/abstracts/tokens' as *;
+
+.combat-damage-floaters {
+  position: relative;
+  width: 0;
+  height: 0;
+  pointer-events: none;
+}
+
+.combat-damage-floater {
+  position: absolute;
+  left: 50%;
+  top: 0;
+  transform: translate(
+    calc(-50% + var(--floater-translate-x, 0px)),
+    calc(-48px + var(--floater-translate-y, 0px))
+  );
+  color: rgba(255, 255, 255, 0.9);
+  font-weight: 600;
+  font-size: var(--font-size-md);
+  text-shadow: 0 0 12px rgba(0, 0, 0, 0.5);
+  will-change: transform, opacity;
+  opacity: 0;
+}
+
+.combat-damage-floater-enter-active,
+.combat-damage-floater-leave-active {
+  transition: transform 0.9s ease-out, opacity 0.9s ease-in;
+}
+
+.combat-damage-floater-enter-from,
+.combat-damage-floater-leave-to {
+  transform: translate(calc(-50% + var(--floater-translate-x, 0px)), 12px);
+  opacity: 0;
+}
+
+.combat-damage-floater-enter-to,
+.combat-damage-floater-leave-from {
+  opacity: 1;
+}
+
+.combat-damage-floater__value {
+  display: inline-block;
+  padding: 0 var(--space-2xs);
+}
+
+.combat-damage-floater--damage {
+  color: rgba(255, 128, 96, 0.95);
+}
+
+.combat-damage-floater--heal {
+  color: rgba(120, 232, 160, 0.95);
+}
+
+.is-fire.combat-damage-floater--damage {
+  color: rgba(255, 156, 96, 0.95);
+  text-shadow: 0 0 14px rgba(255, 96, 0, 0.6);
+}
+
+.is-poison.combat-damage-floater--damage {
+  color: rgba(160, 255, 160, 0.95);
+  text-shadow: 0 0 14px rgba(120, 232, 120, 0.5);
+}
+
+.is-arcane.combat-damage-floater--damage {
+  color: rgba(200, 180, 255, 0.95);
+  text-shadow: 0 0 14px rgba(160, 120, 255, 0.55);
+}
+
+.is-frost.combat-damage-floater--damage {
+  color: rgba(160, 220, 255, 0.95);
+  text-shadow: 0 0 14px rgba(120, 180, 255, 0.55);
+}
+
+.is-heal.combat-damage-floater--heal {
+  color: rgba(144, 255, 196, 0.95);
+  text-shadow: 0 0 14px rgba(120, 255, 200, 0.45);
+}
+</style>

--- a/src/components/combat/CombatDotTracker.vue
+++ b/src/components/combat/CombatDotTracker.vue
@@ -1,0 +1,252 @@
+<template>
+  <div class="combat-dot-tracker">
+    <transition-group
+      name="combat-dot-track"
+      tag="ul"
+      class="combat-dot-tracker__list"
+    >
+      <li
+        v-for="dot in dots"
+        :key="dot.id"
+        class="combat-dot-tracker__entry"
+        :class="dot.classes"
+      >
+        <div class="combat-dot-tracker__meta">
+          <span class="combat-dot-tracker__name">{{ dot.name }}</span>
+          <span class="combat-dot-tracker__stacks" v-if="dot.stacks > 1">
+            ×{{ dot.stacks }}
+          </span>
+        </div>
+        <div class="combat-dot-tracker__bar">
+          <div
+            class="combat-dot-tracker__fill"
+            :style="{ width: dot.progress }"
+          />
+        </div>
+        <span class="combat-dot-tracker__timer">{{ dot.remaining }}</span>
+      </li>
+    </transition-group>
+    <div
+      v-if="!dots.length"
+      class="combat-dot-tracker__empty"
+    >
+      <slot name="empty">No active damage over time effects</slot>
+    </div>
+  </div>
+</template>
+
+<script>
+import { mapStores } from 'pinia';
+
+import { useCombatStore } from '@/stores/combat.js';
+import { resolveEffectMetadata, resolveDamageCue } from './fx.js';
+
+const formatSeconds = (ms) => {
+  const seconds = Math.max(0, Math.round(ms / 100) / 10);
+  return `${seconds.toFixed(seconds >= 10 ? 0 : 1)}s`;
+};
+
+const normaliseEffectName = (effect) => effect?.name || effect?.description || effect?.id || 'Effect';
+
+export default {
+  name: 'CombatDotTracker',
+  props: {
+    entityId: {
+      type: [String, Number],
+      required: true,
+    },
+  },
+  data() {
+    return {
+      subscriptionEnsured: false,
+    };
+  },
+  computed: {
+    ...mapStores(useCombatStore),
+    entity() {
+      return this.combatStore.entities[this.entityId] || null;
+    },
+    activeEffects() {
+      if (!this.entity) {
+        return [];
+      }
+
+      const effects = Array.isArray(this.entity.activeEffects)
+        ? this.entity.activeEffects
+        : Array.isArray(this.entity.combatState?.activeEffects)
+          ? this.entity.combatState.activeEffects
+          : [];
+
+      return effects.filter((effect) => effect && effect.type === 'damage');
+    },
+    dots() {
+      return this.activeEffects.map((effect) => {
+        const metadata = resolveEffectMetadata(effect.id) || {};
+        const totalMs = Number(
+          effect.totalDurationMs
+          ?? effect.durationMs
+          ?? effect.duration
+          ?? effect.remaining
+          ?? 0,
+        );
+        const remainingMs = Number(
+          effect.remainingDurationMs
+          ?? effect.remaining
+          ?? effect.timeRemaining
+          ?? 0,
+        );
+        const tickInterval = Number(effect.tickIntervalMs ?? effect.tickInterval ?? 0);
+        const stacks = Number.isFinite(effect.stacks) ? Math.max(1, Math.round(effect.stacks)) : 1;
+        const boundedRemaining = Number.isFinite(remainingMs) ? remainingMs : 0;
+        const total = Number.isFinite(totalMs) ? totalMs : boundedRemaining;
+        const remaining = total > 0 ? Math.min(boundedRemaining, total) : boundedRemaining;
+        const progress = total > 0 ? Math.max(0, Math.min(1, remaining / total)) : 0;
+        const damageType = effect.damageType || metadata.damageType || 'general';
+        const cue = resolveDamageCue(damageType, 'general');
+
+        const displayRemaining = Math.max(0, remaining);
+
+        return {
+          id: effect.instanceId || `${effect.targetId || this.entityId}:${effect.id}`,
+          name: normaliseEffectName(effect),
+          progress: `${Math.round(progress * 100)}%`,
+          remaining: formatSeconds(displayRemaining),
+          stacks,
+          tickInterval,
+          classes: [cue.className],
+        };
+      });
+    },
+  },
+  watch: {
+    combatStore: {
+      handler() {
+        this.ensureSubscription();
+      },
+      immediate: true,
+    },
+  },
+  mounted() {
+    this.ensureSubscription();
+  },
+  methods: {
+    ensureSubscription() {
+      if (this.subscriptionEnsured) {
+        return;
+      }
+
+      if (this.combatStore && typeof this.combatStore.ensureSubscriptions === 'function') {
+        this.combatStore.ensureSubscriptions();
+        this.subscriptionEnsured = true;
+      }
+    },
+  },
+};
+</script>
+
+<style scoped lang="scss">
+@use '@/assets/scss/abstracts/tokens' as *;
+
+.combat-dot-tracker {
+  width: min(280px, 100%);
+  padding: var(--space-xs);
+  border-radius: var(--radius-md);
+  background: rgba(10, 14, 20, 0.7);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.05);
+  backdrop-filter: blur(6px);
+  color: var(--surface-text-strong);
+}
+
+.combat-dot-tracker__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: var(--space-2xs);
+}
+
+.combat-dot-tracker__entry {
+  display: grid;
+  gap: var(--space-3xs);
+  padding: var(--space-3xs) var(--space-2xs);
+  border-radius: var(--radius-sm);
+  background: rgba(255, 255, 255, 0.04);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.08);
+}
+
+.combat-dot-tracker__meta {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3xs);
+  justify-content: space-between;
+  font-size: var(--font-size-xs);
+  text-transform: uppercase;
+}
+
+.combat-dot-tracker__name {
+  font-weight: 600;
+}
+
+.combat-dot-tracker__stacks {
+  font-weight: 500;
+  color: rgba(255, 255, 255, 0.65);
+}
+
+.combat-dot-tracker__bar {
+  position: relative;
+  height: var(--space-2xs);
+  border-radius: var(--radius-pill);
+  overflow: hidden;
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.combat-dot-tracker__fill {
+  height: 100%;
+  background: linear-gradient(90deg, rgba(255, 136, 0, 0.85), rgba(255, 198, 0, 0.7));
+  transition: width 160ms ease-out;
+}
+
+.combat-dot-tracker__timer {
+  justify-self: end;
+  font-size: var(--font-size-2xs);
+  font-variant-numeric: tabular-nums;
+  color: rgba(255, 255, 255, 0.6);
+}
+
+.combat-dot-tracker__empty {
+  font-size: var(--font-size-xs);
+  text-align: center;
+  padding: var(--space-2xs) 0;
+  color: rgba(255, 255, 255, 0.5);
+}
+
+.combat-dot-track-enter-active,
+.combat-dot-track-leave-active {
+  transition: all 160ms ease;
+}
+
+.combat-dot-track-enter-from,
+.combat-dot-track-leave-to {
+  opacity: 0;
+  transform: translateY(-4px);
+}
+
+.is-fire .combat-dot-tracker__fill {
+  background: linear-gradient(90deg, rgba(255, 96, 0, 0.9), rgba(255, 196, 120, 0.7));
+  box-shadow: 0 0 10px rgba(255, 128, 0, 0.45);
+}
+
+.is-poison .combat-dot-tracker__fill {
+  background: linear-gradient(90deg, rgba(120, 232, 120, 0.9), rgba(180, 255, 180, 0.65));
+  box-shadow: 0 0 10px rgba(120, 232, 120, 0.4);
+}
+
+.is-physical .combat-dot-tracker__fill {
+  background: linear-gradient(90deg, rgba(200, 200, 200, 0.9), rgba(255, 255, 255, 0.6));
+  box-shadow: 0 0 10px rgba(200, 200, 200, 0.4);
+}
+
+.is-generic .combat-dot-tracker__fill {
+  background: linear-gradient(90deg, rgba(180, 180, 180, 0.9), rgba(240, 240, 240, 0.65));
+}
+</style>

--- a/src/components/combat/CombatHealthBar.vue
+++ b/src/components/combat/CombatHealthBar.vue
@@ -1,0 +1,228 @@
+<template>
+  <div
+    v-if="resolvedEntity"
+    class="combat-health-bar"
+    :class="healthBarClasses"
+  >
+    <div class="combat-health-bar__label">
+      <slot name="label">
+        {{ resolvedEntity.name || 'Unknown' }}
+      </slot>
+      <span v-if="showValues" class="combat-health-bar__values">
+        {{ currentHealth }} / {{ maxHealth }}
+      </span>
+    </div>
+    <div class="combat-health-bar__track">
+      <div
+        class="combat-health-bar__fill"
+        :style="{ width: fillPercentage }"
+      />
+    </div>
+  </div>
+  <div v-else class="combat-health-bar combat-health-bar--placeholder">
+    <div class="combat-health-bar__label">
+      <slot name="placeholder-label">No entity</slot>
+    </div>
+    <div class="combat-health-bar__track">
+      <div class="combat-health-bar__fill combat-health-bar__fill--empty" />
+    </div>
+  </div>
+</template>
+
+<script>
+import { mapStores } from 'pinia';
+
+import { useCombatStore } from '@/stores/combat.js';
+
+export default {
+  name: 'CombatHealthBar',
+  props: {
+    entityId: {
+      type: [String, Number],
+      default: null,
+    },
+    entity: {
+      type: Object,
+      default: null,
+    },
+    showValues: {
+      type: Boolean,
+      default: true,
+    },
+  },
+  data() {
+    return {
+      subscriptionEnsured: false,
+    };
+  },
+  computed: {
+    ...mapStores(useCombatStore),
+    resolvedEntityId() {
+      if (this.entity && this.entity.id) {
+        return this.entity.id;
+      }
+
+      return this.entityId;
+    },
+    entityFromStore() {
+      if (!this.resolvedEntityId) {
+        return null;
+      }
+
+      return this.combatStore.entities[this.resolvedEntityId] || null;
+    },
+    resolvedEntity() {
+      return this.entity || this.entityFromStore;
+    },
+    health() {
+      if (!this.resolvedEntity) {
+        return { current: 0, max: 1 };
+      }
+
+      const candidate = this.resolvedEntity.health
+        || this.resolvedEntity.resources?.health
+        || this.resolvedEntity.stats?.resources?.health
+        || this.resolvedEntity.stats?.health
+        || null;
+
+      if (!candidate) {
+        const current = Number(this.resolvedEntity?.healthCurrent ?? 0);
+        const max = Number(this.resolvedEntity?.healthMax ?? 1);
+        return {
+          current: Number.isFinite(current) ? current : 0,
+          max: Number.isFinite(max) && max > 0 ? max : 1,
+        };
+      }
+
+      if (typeof candidate === 'number') {
+        const max = Number(candidate) || 1;
+        return { current: max, max };
+      }
+
+      const current = Number(candidate.current ?? candidate.value ?? 0);
+      const max = Number(candidate.max ?? candidate.maximum ?? candidate.capacity ?? 1);
+      return {
+        current: Number.isFinite(current) ? current : 0,
+        max: Number.isFinite(max) && max > 0 ? max : 1,
+      };
+    },
+    currentHealth() {
+      return Math.max(0, Math.round(this.health.current));
+    },
+    maxHealth() {
+      return Math.max(1, Math.round(this.health.max));
+    },
+    fillRatio() {
+      if (!this.maxHealth) {
+        return 0;
+      }
+
+      return Math.min(1, Math.max(0, this.currentHealth / this.maxHealth));
+    },
+    fillPercentage() {
+      return `${Math.round(this.fillRatio * 100)}%`;
+    },
+    healthBarClasses() {
+      const percent = this.fillRatio * 100;
+      if (percent <= 20) {
+        return ['combat-health-bar--critical'];
+      }
+      if (percent <= 50) {
+        return ['combat-health-bar--wounded'];
+      }
+      return ['combat-health-bar--healthy'];
+    },
+  },
+  watch: {
+    combatStore: {
+      handler() {
+        this.ensureSubscription();
+      },
+      immediate: true,
+    },
+  },
+  mounted() {
+    this.ensureSubscription();
+  },
+  methods: {
+    ensureSubscription() {
+      if (this.subscriptionEnsured) {
+        return;
+      }
+
+      if (this.combatStore && typeof this.combatStore.ensureSubscriptions === 'function') {
+        this.combatStore.ensureSubscriptions();
+        this.subscriptionEnsured = true;
+      }
+    },
+  },
+};
+</script>
+
+<style scoped lang="scss">
+@use '@/assets/scss/abstracts/tokens' as *;
+
+.combat-health-bar {
+  display: grid;
+  gap: var(--space-2xs);
+  width: min(100%, 320px);
+  padding: var(--space-2xs) var(--space-xs);
+  border-radius: var(--radius-md);
+  background: rgba(12, 18, 24, 0.65);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.08);
+  backdrop-filter: blur(4px);
+  color: var(--surface-text-strong);
+}
+
+.combat-health-bar__label {
+  display: flex;
+  justify-content: space-between;
+  font-size: var(--font-size-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.combat-health-bar__values {
+  font-weight: 600;
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.combat-health-bar__track {
+  position: relative;
+  height: var(--space-sm);
+  border-radius: var(--radius-pill);
+  overflow: hidden;
+  background: rgba(255, 255, 255, 0.06);
+}
+
+.combat-health-bar__fill {
+  height: 100%;
+  transition: width 120ms ease-in;
+  background: linear-gradient(90deg, rgba(220, 68, 68, 0.9), rgba(255, 136, 136, 0.9));
+  box-shadow: 0 0 12px rgba(255, 64, 64, 0.45);
+}
+
+.combat-health-bar__fill--empty {
+  width: 100%;
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.combat-health-bar--healthy .combat-health-bar__fill {
+  background: linear-gradient(90deg, rgba(68, 176, 104, 0.9), rgba(136, 232, 168, 0.9));
+  box-shadow: 0 0 12px rgba(72, 208, 124, 0.45);
+}
+
+.combat-health-bar--wounded .combat-health-bar__fill {
+  background: linear-gradient(90deg, rgba(232, 168, 64, 0.9), rgba(255, 212, 136, 0.9));
+  box-shadow: 0 0 12px rgba(232, 168, 64, 0.45);
+}
+
+.combat-health-bar--critical .combat-health-bar__fill {
+  background: linear-gradient(90deg, rgba(220, 68, 68, 0.9), rgba(255, 120, 120, 0.9));
+  box-shadow: 0 0 12px rgba(220, 68, 68, 0.6);
+}
+
+.combat-health-bar--placeholder {
+  opacity: 0.6;
+}
+</style>

--- a/src/components/combat/fx.js
+++ b/src/components/combat/fx.js
@@ -1,0 +1,155 @@
+import bus from '@/core/utilities/bus.js';
+import { ABILITIES } from '@/core/config/combat/abilities.js';
+
+const normaliseKey = (value, fallback = 'general') => {
+  if (!value) {
+    return fallback;
+  }
+
+  return String(value).toLowerCase();
+};
+
+const abilityLookup = ABILITIES.reduce((acc, ability) => {
+  acc[ability.id] = ability;
+  return acc;
+}, {});
+
+const effectLookup = ABILITIES.reduce((acc, ability) => {
+  (ability.effects || []).forEach((effect) => {
+    if (!effect || !effect.id) {
+      return;
+    }
+
+    acc[effect.id] = {
+      abilityId: ability.id,
+      abilityName: ability.name,
+      damageType: effect.damageType || null,
+      category: ability.category || 'general',
+    };
+  });
+  return acc;
+}, {});
+
+const DAMAGE_TYPE_CUES = {
+  physical: {
+    sound: 'combat.hit.physical',
+    particle: 'impact-sparks',
+    className: 'is-physical',
+  },
+  fire: {
+    sound: 'combat.hit.fire',
+    particle: 'ember-burst',
+    className: 'is-fire',
+  },
+  poison: {
+    sound: 'combat.hit.poison',
+    particle: 'spore-cloud',
+    className: 'is-poison',
+  },
+  frost: {
+    sound: 'combat.hit.frost',
+    particle: 'frost-shard',
+    className: 'is-frost',
+  },
+  arcane: {
+    sound: 'combat.hit.arcane',
+    particle: 'arcane-flare',
+    className: 'is-arcane',
+  },
+  heal: {
+    sound: 'combat.heal',
+    particle: 'healing-motes',
+    className: 'is-heal',
+  },
+  general: {
+    sound: 'combat.hit',
+    particle: 'impact-generic',
+    className: 'is-generic',
+  },
+};
+
+const ABILITY_CATEGORY_CUES = {
+  active: {
+    sound: 'ability.cast.active',
+    particle: 'ability-active',
+    className: 'is-active',
+  },
+  passive: {
+    sound: 'ability.cast.passive',
+    particle: 'ability-passive',
+    className: 'is-passive',
+  },
+  ultimate: {
+    sound: 'ability.cast.ultimate',
+    particle: 'ability-ultimate',
+    className: 'is-ultimate',
+  },
+  general: {
+    sound: 'ability.cast',
+    particle: 'ability-general',
+    className: 'is-general',
+  },
+};
+
+export const resolveAbilityCategory = (abilityId) => {
+  const ability = abilityLookup[abilityId];
+  return ability?.category || 'general';
+};
+
+export const getAbilityDefinition = (abilityId) => abilityLookup[abilityId] || null;
+
+export const resolveAbilityPrimaryDamageType = (abilityId) => {
+  const ability = abilityLookup[abilityId];
+  if (!ability) {
+    return null;
+  }
+
+  const effectWithDamage = (ability.effects || []).find((effect) => effect.damageType);
+  return effectWithDamage?.damageType || null;
+};
+
+export const resolveEffectMetadata = (effectId) => effectLookup[effectId] || null;
+
+export const resolveDamageCue = (damageType, fallback = 'general') => {
+  const key = normaliseKey(damageType, fallback);
+  return DAMAGE_TYPE_CUES[key] || DAMAGE_TYPE_CUES[fallback] || DAMAGE_TYPE_CUES.general;
+};
+
+export const resolveAbilityCue = (abilityId) => {
+  const category = resolveAbilityCategory(abilityId);
+  const key = normaliseKey(category, 'general');
+  const cue = ABILITY_CATEGORY_CUES[key] || ABILITY_CATEGORY_CUES.general;
+  return { ...cue, category };
+};
+
+export const triggerSoundCue = (soundId) => {
+  if (!soundId) {
+    return;
+  }
+
+  bus.$emit('AUDIO:PLAY', { soundId });
+};
+
+export const triggerParticleCue = (options = {}) => {
+  if (!options || !options.particle) {
+    return;
+  }
+
+  bus.$emit('FX:PARTICLE', {
+    particle: options.particle,
+    entityId: options.entityId || null,
+    category: options.category || null,
+    damageType: options.damageType || null,
+  });
+};
+
+export default {
+  getAbilityDefinition,
+  resolveAbilityCategory,
+  resolveAbilityPrimaryDamageType,
+  resolveEffectMetadata,
+  resolveDamageCue,
+  resolveAbilityCue,
+  triggerSoundCue,
+  triggerParticleCue,
+};

--- a/src/components/combat/index.js
+++ b/src/components/combat/index.js
@@ -1,0 +1,6 @@
+export { default as CombatHealthBar } from './CombatHealthBar.vue';
+export { default as CombatDotTracker } from './CombatDotTracker.vue';
+export { default as CombatCooldownWheel } from './CombatCooldownWheel.vue';
+export { default as CombatDamageFloaters } from './CombatDamageFloaters.vue';
+
+export * from './fx.js';


### PR DESCRIPTION
## Summary
- add reusable combat HUD components for health, damage-over-time, cooldowns, and floating combat text that stay in sync with the combat store
- map damage types and ability categories to visual styles and audio/particle bus events for responsive feedback
- expose the new combat UI suite through a barrel export for easy reuse

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e84deb77483218e1aa1eb69495d8f)