### PR TITLE
fix: bind socket actions to authenticated players

### DIFF
--- a/server/Delaford.js
+++ b/server/Delaford.js
@@ -53,6 +53,67 @@ class Delaford {
     Monster.load(this);
   }
 
+  static getSocketPlayer(ws) {
+    if (!ws || !ws.id) {
+      return null;
+    }
+
+    return world.players.find(player => player.socket_id === ws.id) || null;
+  }
+
+  static isForeignIdentifier(player, value) {
+    return Boolean(value && value !== player.uuid && value !== player.socket_id);
+  }
+
+  static hasForeignPlayerReference(player, payload = {}) {
+    if (!payload || typeof payload !== 'object') {
+      return false;
+    }
+
+    if (Delaford.isForeignIdentifier(player, payload.id)
+      || Delaford.isForeignIdentifier(player, payload.uuid)
+      || Delaford.isForeignIdentifier(player, payload.socket_id)) {
+      return true;
+    }
+
+    if (payload.player && typeof payload.player === 'object') {
+      return Delaford.isForeignIdentifier(player, payload.player.id)
+        || Delaford.isForeignIdentifier(player, payload.player.uuid)
+        || Delaford.isForeignIdentifier(player, payload.player.socket_id);
+    }
+
+    return false;
+  }
+
+  static authorizeSocketMessage(data, ws, publicEvents) {
+    if (publicEvents.has(data.event)) {
+      return true;
+    }
+
+    const player = Delaford.getSocketPlayer(ws);
+    if (!player) {
+      console.warn(`[socket] Authenticated socket ${ws.id.substring(0, 5)}... has no bound player for "${data.event}".`);
+      return false;
+    }
+
+    const payload = data.data || {};
+    if (Delaford.hasForeignPlayerReference(player, payload)
+      || Delaford.hasForeignPlayerReference(player, payload.data || {})) {
+      console.warn(`[socket] Rejected foreign player reference from ${ws.id.substring(0, 5)}... event="${data.event}".`);
+      return false;
+    }
+
+    if (payload && typeof payload === 'object') {
+      payload.player = {
+        ...(payload.player || {}),
+        uuid: player.uuid,
+        socket_id: player.socket_id,
+      };
+    }
+
+    return true;
+  }
+
   /**
    * Create the new server with the port
    */
@@ -290,6 +351,10 @@ class Delaford {
       // Require authentication for non-public events
       if (!PUBLIC_EVENTS.has(data.event) && !ws.authenticated) {
         console.warn(`[socket] Unauthenticated event "${data.event}" from ${ws.id.substring(0, 5)}...`);
+        return;
+      }
+
+      if (!this.constructor.authorizeSocketMessage(data, ws, PUBLIC_EVENTS)) {
         return;
       }
 

--- a/server/player/handlers/socket-events/index.js
+++ b/server/player/handlers/socket-events/index.js
@@ -9,14 +9,30 @@ import config from '#server/config.js';
 import playerGuest from '#server/core/data/helpers/player.json' with { type: 'json' };
 import world from '#server/core/world.js';
 
+const getPlayerBySocket = (ws) => {
+  if (!ws || !ws.id) {
+    return null;
+  }
+
+  return world.players.find(player => player.socket_id === ws.id) || null;
+};
+
+const isSpoofedPlayerPayload = (player, payload = {}) => (
+  Boolean(payload.id && payload.id !== player.uuid)
+  || Boolean(payload.uuid && payload.uuid !== player.uuid)
+  || Boolean(payload.socket_id && payload.socket_id !== player.socket_id)
+);
+
 export default {
   /**
    * A player logins into the game
    */
   'player:login': async (data, ws) => {
+    const payload = data.data || {};
+
     try {
-      if (!data.data.useGuestAccount) {
-        const { player, token } = await Authentication.login(data);
+      if (!payload.useGuestAccount) {
+        const { player, token } = await Authentication.login({ ...data, data: payload });
         Authentication.addPlayer(new Player(player, token, ws.id));
       } else {
         Authentication.addPlayer(new Player(playerGuest, 'none', ws.id));
@@ -24,7 +40,8 @@ export default {
       ws.authenticated = true;
     } catch (error) {
       console.log(error);
-      console.log(`${data.data.username} logged in with a bad password.`);
+      const username = typeof payload.username === 'string' ? payload.username : 'unknown user';
+      console.log(`${username} logged in with a bad password.`);
 
       Socket.emit('player:login-error', {
         data: error && error.message ? error.message : 'Login failed.',
@@ -43,15 +60,15 @@ export default {
   /**
    * A player sends a chat message to everyone
    */
-  'player:say': ({ data }) => {
-    const { id, said } = data;
+  'player:say': ({ data }, ws) => {
+    const { said } = data || {};
     const { viewport } = config.map;
 
     if (typeof said !== 'string' || !said.trim()) {
       return;
     }
 
-    const speaker = world.players.find(p => p.socket_id === id);
+    const speaker = getPlayerBySocket(ws);
     if (!speaker) {
       return;
     }
@@ -87,28 +104,24 @@ export default {
   /**
    * A player moves to a new tile via keyboard
    */
-  'player:move': (data) => {
+  'player:move': (data, ws) => {
     const payload = data.data || {};
-    const playerIndex = world.players.findIndex(player => player.uuid === payload.id);
-    if (playerIndex === -1) {
+    const player = getPlayerBySocket(ws);
+    if (!player || isSpoofedPlayerPayload(player, payload)) {
       return;
     }
-
-    const player = world.players[playerIndex];
     const startedAt = Date.now();
     player.move(payload.direction, { startedAt, direction: payload.direction });
 
     Player.broadcastMovement(player);
   },
 
-  'player:skill:trigger': (data) => {
+  'player:skill:trigger': (data, ws) => {
     const payload = data.data || {};
-    const playerIndex = world.players.findIndex(player => player.uuid === payload.id);
-    if (playerIndex === -1) {
+    const player = getPlayerBySocket(ws);
+    if (!player || isSpoofedPlayerPayload(player, payload)) {
       return;
     }
-
-    const player = world.players[playerIndex];
     const triggered = player.recordSkillInput(payload.skillId, {
       direction: payload.direction,
       modifiers: payload.modifiers,
@@ -132,17 +145,13 @@ export default {
   /**
    * Queue up a player action to be executed when they reach their destination
    */
-  'player:queueAction': (data) => {
-    if (!data.player || !data.player.socket_id) {
+  'player:queueAction': (data, ws) => {
+    const player = getPlayerBySocket(ws);
+    if (!player) {
       return;
     }
 
-    const playerIndex = world.players.findIndex(p => p.socket_id === data.player.socket_id);
-    if (playerIndex === -1) {
-      return;
-    }
-
-    const player = world.players[playerIndex];
+    data.player = { ...(data.player || {}), socket_id: player.socket_id };
     if (player.queue.length >= 20) {
       return;
     }
@@ -150,17 +159,13 @@ export default {
     player.action = data.actionToQueue;
   },
 
-  'player:pane:close': (data) => {
+  'player:pane:close': (data, ws) => {
     const payload = data.data || {};
-    if (!payload.id) {
+    const player = getPlayerBySocket(ws);
+    if (!player || isSpoofedPlayerPayload(player, payload)) {
       return;
     }
 
-    const playerIndex = world.players.findIndex(p => p.uuid === payload.id);
-    if (playerIndex === -1) {
-      return;
-    }
-
-    world.players[playerIndex].currentPane = false;
+    player.currentPane = false;
   },
 };

--- a/tests/unit/socket-events-authorization.spec.js
+++ b/tests/unit/socket-events-authorization.spec.js
@@ -1,0 +1,150 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('#server/socket.js', () => ({
+  default: {
+    emit: vi.fn(),
+    broadcast: vi.fn(),
+  },
+}));
+
+vi.mock('#server/core/player.js', () => ({
+  default: {
+    broadcastMovement: vi.fn(),
+    broadcastAnimation: vi.fn(),
+  },
+}));
+
+vi.mock('#server/player/authentication.js', () => ({
+  default: {
+    login: vi.fn(),
+    logout: vi.fn(),
+    addPlayer: vi.fn(),
+  },
+}));
+
+vi.mock('#server/config.js', () => ({
+  default: {
+    map: {
+      viewport: { x: 16, y: 10 },
+    },
+  },
+}));
+
+vi.mock('#server/core/world.js', () => ({
+  default: {
+    _players: [],
+    get players() { return this._players; },
+    set players(value) { this._players = value; },
+    getScenePlayers: vi.fn(() => []),
+  },
+}));
+
+const { default: socketEvents } = await import('#server/player/handlers/socket-events/index.js');
+const { default: Socket } = await import('#server/socket.js');
+const { default: Player } = await import('#server/core/player.js');
+const { default: world } = await import('#server/core/world.js');
+
+const createPlayer = (overrides = {}) => ({
+  uuid: 'player-a',
+  socket_id: 'socket-a',
+  username: 'Alice',
+  x: 10,
+  y: 10,
+  sceneId: 'town',
+  queue: [],
+  currentPane: 'inventory',
+  combat: { sequence: 0 },
+  animation: { state: 'idle' },
+  move: vi.fn(),
+  recordSkillInput: vi.fn(() => true),
+  ...overrides,
+});
+
+describe('socket event authorization', () => {
+  let alice;
+  let bob;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    alice = createPlayer();
+    bob = createPlayer({
+      uuid: 'player-b',
+      socket_id: 'socket-b',
+      username: 'Bob',
+      x: 12,
+      y: 10,
+      currentPane: 'stats',
+    });
+    world.players = [alice, bob];
+    world.getScenePlayers.mockReturnValue([alice, bob]);
+  });
+
+  it('moves only the player bound to the authenticated socket', () => {
+    socketEvents['player:move'](
+      { data: { id: 'player-a', direction: 'up' } },
+      { id: 'socket-a' },
+    );
+
+    expect(alice.move).toHaveBeenCalledWith('up', expect.objectContaining({ direction: 'up' }));
+    expect(bob.move).not.toHaveBeenCalled();
+    expect(Player.broadcastMovement).toHaveBeenCalledWith(alice);
+  });
+
+  it('rejects movement attempts that spoof another player uuid', () => {
+    socketEvents['player:move'](
+      { data: { id: 'player-b', direction: 'left' } },
+      { id: 'socket-a' },
+    );
+
+    expect(alice.move).not.toHaveBeenCalled();
+    expect(bob.move).not.toHaveBeenCalled();
+    expect(Player.broadcastMovement).not.toHaveBeenCalled();
+  });
+
+  it('uses the socket-bound player as the chat speaker instead of the client-supplied id', () => {
+    socketEvents['player:say'](
+      { data: { id: 'socket-b', said: 'hello' } },
+      { id: 'socket-a' },
+    );
+
+    expect(Socket.broadcast).toHaveBeenCalledWith(
+      'player:say',
+      { username: 'Alice', type: 'chat', text: 'hello' },
+      [alice, bob],
+    );
+  });
+
+  it('queues actions on the socket-bound player and rewrites spoofed socket ids', () => {
+    const action = {
+      player: { socket_id: 'socket-b' },
+      actionToQueue: 'mine',
+    };
+
+    socketEvents['player:queueAction'](action, { id: 'socket-a' });
+
+    expect(alice.queue).toHaveLength(1);
+    expect(alice.queue[0].player.socket_id).toBe('socket-a');
+    expect(alice.action).toBe('mine');
+    expect(bob.queue).toHaveLength(0);
+  });
+
+  it('closes only the pane owned by the socket-bound player', () => {
+    socketEvents['player:pane:close'](
+      { data: { id: 'player-a' } },
+      { id: 'socket-a' },
+    );
+
+    expect(alice.currentPane).toBe(false);
+    expect(bob.currentPane).toBe('stats');
+  });
+
+  it('rejects pane-close attempts that spoof another player uuid', () => {
+    socketEvents['player:pane:close'](
+      { data: { id: 'player-b' } },
+      { id: 'socket-a' },
+    );
+
+    expect(alice.currentPane).toBe('inventory');
+    expect(bob.currentPane).toBe('stats');
+  });
+});

--- a/tests/unit/ws-message-handler.spec.js
+++ b/tests/unit/ws-message-handler.spec.js
@@ -83,6 +83,7 @@ vi.mock('#server/player/handler.js', () => ({
     'player:login': vi.fn(),
     'player:move': vi.fn(),
     'player:say': vi.fn(),
+    'player:context-menu:action': vi.fn(),
   },
 }));
 
@@ -173,6 +174,7 @@ describe('Delaford.connection – message handler validation', () => {
     // Create a mock WebSocket and run it through the real connection method
     ws = createMockWs();
     game.connection(ws);
+    world.players = [{ uuid: 'abc', socket_id: ws.id }];
     // After connection, ws.authenticated is still false (requires login)
     // Set authenticated for general handler tests
     ws.authenticated = true;
@@ -216,10 +218,27 @@ describe('Delaford.connection – message handler validation', () => {
     const payload = { event: 'player:say', data: { said: 'hello' } };
     await ws._triggerMessage(JSON.stringify(payload));
     expect(Handler['player:say']).toHaveBeenCalledWith(
-      payload,
+      {
+        event: 'player:say',
+        data: {
+          said: 'hello',
+          player: { uuid: 'abc', socket_id: ws.id },
+        },
+      },
       ws,
       game,
     );
+  });
+
+  it('rejects authenticated messages that reference another player', async () => {
+    const msg = JSON.stringify({
+      event: 'player:context-menu:action',
+      data: { player: { socket_id: 'other-socket' } },
+    });
+
+    await ws._triggerMessage(msg);
+
+    expect(Handler['player:context-menu:action']).not.toHaveBeenCalled();
   });
 
   it('rejects null message body', async () => {
@@ -261,6 +280,7 @@ describe('Delaford.connection – authentication gate', () => {
   });
 
   it('allows non-login events after authentication', async () => {
+    world.players = [{ uuid: 'abc', socket_id: ws.id }];
     ws.authenticated = true;
     const msg = JSON.stringify({ event: 'player:move', data: {} });
     await ws._triggerMessage(msg);
@@ -280,6 +300,7 @@ describe('Delaford.connection – rate limiting', () => {
     game = new Delaford(mockServer);
     ws = createMockWs();
     game.connection(ws);
+    world.players = [{ uuid: 'abc', socket_id: ws.id }];
     ws.authenticated = true;
   });
 


### PR DESCRIPTION
### Motivation
- Prevent authenticated WebSocket connections from acting on behalf of other players by trusting client-supplied uuids/socket ids in high-traffic socket handlers. 
- Make the socket-to-player binding authoritative at the dispatch boundary to reduce exploitation surface for movement, chat, pane, and queued actions.

### Description
- Add an authorization pass to the WebSocket dispatcher in `server/Delaford.js` via `authorizeSocketMessage` and helpers `getSocketPlayer`, `hasForeignPlayerReference`, and `isForeignIdentifier` that reject messages referencing foreign player identifiers and inject the trusted `player` into the payload. 
- Update socket handlers in `server/player/handlers/socket-events/index.js` to resolve the player from the socket and refuse spoofed payloads for `player:move`, `player:say`, `player:skill:trigger`, `player:queueAction`, and `player:pane:close`, and harden login payload handling. 
- Add focused unit tests `tests/unit/socket-events-authorization.spec.js` and update `tests/unit/ws-message-handler.spec.js` to assert that spoofed player references are rejected and that the dispatcher injects the socket-bound `player` into handler payloads. 
- Commit message: `fix: bind socket actions to authenticated players`.

### Testing
- Ran `npm run lint` and the linter completed without errors. 
- Ran unit tests with `npm run test:unit` and the test suite passed (all unit tests succeeded, including the new authorization tests). 
- Ran `npm run lint:css` (stylelint) and `npm run build` (Vite) and both completed successfully (build emitted standard Browserslist/Sass warnings but finished).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a24a59d81e88321a6e2ebd6541493a7)