### PR TITLE
Improve gameplay controls and HUD usability

### DIFF
--- a/src/components/GameCanvas.vue
+++ b/src/components/GameCanvas.vue
@@ -300,6 +300,15 @@ export default {
      */
     leftClick(event) {
       bus.$emit('screen:close');
+
+      if (!this.currentAction || !this.currentAction.action) {
+        bus.$emit('contextmenu:close');
+        if (typeof window.focusOnGame === 'function') {
+          window.focusOnGame();
+        }
+        return;
+      }
+
       bus.$emit('canvas:select-action', {
         event,
         item: this.currentAction,

--- a/src/components/hud/Quickbar.vue
+++ b/src/components/hud/Quickbar.vue
@@ -8,13 +8,18 @@
       <button
         class="quickbar__activate"
         type="button"
-        :title="slot.label"
+        :title="slotTitle(slot, index)"
+        :disabled="!slot.skillId"
         @click="$emit('slot-activate', slot, index)"
       >
         <span class="quickbar__icon" aria-hidden="true">
           <span v-if="slot.icon">{{ slot.icon }}</span>
         </span>
         <span class="quickbar__label">{{ slot.label || `Slot ${index + 1}` }}</span>
+        <span
+          v-if="slot.skill && slot.skill.cooldown"
+          class="quickbar__cooldown"
+        >{{ slot.skill.cooldown }}s</span>
       </button>
       <button
         class="quickbar__remap"
@@ -43,6 +48,14 @@ export default {
     },
   },
   emits: ['slot-activate', 'request-remap'],
+  methods: {
+    slotTitle(slot, index) {
+      const label = slot.label || `Slot ${index + 1}`;
+      const hotkey = slot.hotkey ? ` [${slot.hotkey}]` : '';
+      const description = slot.skill && slot.skill.description ? ` — ${slot.skill.description}` : '';
+      return `${label}${hotkey}${description}`;
+    },
+  },
 };
 </script>
 
@@ -103,6 +116,11 @@ export default {
     outline: 2px solid var(--color-accent);
     outline-offset: -2px;
   }
+
+  &:disabled {
+    cursor: not-allowed;
+    opacity: 0.58;
+  }
 }
 
 .quickbar__icon {
@@ -120,6 +138,12 @@ export default {
   font-size: var(--font-size-sm);
   letter-spacing: 0.04em;
   text-transform: uppercase;
+}
+
+.quickbar__cooldown {
+  font-size: 0.7rem;
+  color: var(--color-accent-strong);
+  letter-spacing: 0.08em;
 }
 
 .quickbar__remap {

--- a/src/components/layout/GameHUD.vue
+++ b/src/components/layout/GameHUD.vue
@@ -1,5 +1,11 @@
 <template>
   <div class="hud-shell">
+    <div class="hud-shell__hint" aria-label="Controls hint">
+      <span>WASD / Arrows move</span>
+      <span>1–6 skills</span>
+      <span>/ chat</span>
+      <span>Esc close</span>
+    </div>
     <div class="hud-shell__row">
       <HudOrb
         class="hud-shell__orb hud-shell__orb--left"
@@ -78,6 +84,28 @@ export default {
   pointer-events: none;
 }
 
+.hud-shell__hint {
+  display: inline-flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: var(--space-xs);
+  padding: 6px 10px;
+  border-radius: 999px;
+  background: rgba(12, 16, 28, 0.72);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  color: var(--color-text-secondary);
+  font-size: 0.75rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  pointer-events: auto;
+}
+
+.hud-shell__hint span + span::before {
+  content: '•';
+  margin-right: var(--space-xs);
+  opacity: 0.55;
+}
+
 .hud-shell__row {
   width: 100%;
   display: flex;
@@ -114,6 +142,10 @@ export default {
 }
 
 @media (width <= 767px) {
+  .hud-shell__hint {
+    display: none;
+  }
+
   .hud-shell__row {
     flex-direction: column;
     align-items: stretch;

--- a/src/components/sub/ContextMenu.vue
+++ b/src/components/sub/ContextMenu.vue
@@ -103,6 +103,11 @@ export default {
      */
     async selectAction(event, item) {
       // Data to perform action
+      if (!item || !item.action) {
+        this.closeMenu();
+        return;
+      }
+
       const tilePayload = this.getTilePayload();
       const data = {
         item,
@@ -147,8 +152,16 @@ export default {
      * @param {integer} y The y-axis of where the mouse was clicked
      */
     setMenu(x, y) {
-      this.style.left = `${x - 9}px`;
-      this.style.top = `${y - 7}px`;
+      const menu = this.$el && this.$el.querySelector ? this.$el.querySelector('#actions') : null;
+      const menuWidth = menu && menu.offsetWidth ? menu.offsetWidth : 195;
+      const menuHeight = menu && menu.offsetHeight ? menu.offsetHeight : 120;
+      const viewportWidth = typeof window !== 'undefined' ? window.innerWidth : x + menuWidth;
+      const viewportHeight = typeof window !== 'undefined' ? window.innerHeight : y + menuHeight;
+      const left = Math.min(Math.max(0, x - 9), Math.max(0, viewportWidth - menuWidth - 8));
+      const top = Math.min(Math.max(0, y - 7), Math.max(0, viewportHeight - menuHeight - 8));
+
+      this.style.left = `${left}px`;
+      this.style.top = `${top}px`;
     },
 
     /**
@@ -223,6 +236,11 @@ export default {
       this.items = data.data.data
         .sort((a, b) => b.timestamp - a.timestamp) // Sort by when item appeared
         .sort((a, b) => a.action.weight - b.action.weight); // then by action weight
+
+      if (this.items.length === 0) {
+        this.closeMenu();
+        return;
+      }
 
       // Ready to show
       this.view = true;

--- a/src/components/ui/panes/FloatingWindow.vue
+++ b/src/components/ui/panes/FloatingWindow.vue
@@ -190,13 +190,15 @@ export default {
       if (!dragging.value) {
         return;
       }
+
+      const shouldSnap = props.snapDocking && props.dock === 'floating' && dragMoved.value;
       dragging.value = false;
       dragStartedFromDock.value = false;
       dragMoved.value = false;
       window.removeEventListener('pointermove', handlePointerMove);
       window.removeEventListener('pointerup', stopDragging);
 
-      if (props.snapDocking && props.dock === 'floating' && dragMoved.value) {
+      if (shouldSnap) {
         snapToEdge();
       }
     };
@@ -254,9 +256,22 @@ export default {
       window.addEventListener('pointerup', stopDragging);
     };
 
+    const clampFloatingPosition = (position = {}) => {
+      const bounds = props.bounds || {};
+      const rect = windowRef.value ? windowRef.value.getBoundingClientRect() : null;
+      const width = rect ? rect.width : 0;
+      const height = rect ? rect.height : 0;
+      const maxX = Math.max(0, (bounds.width || 0) - width);
+      const maxY = Math.max(0, (bounds.height || 0) - height);
+      return {
+        x: clamp(position.x || 0, 0, maxX || 0),
+        y: clamp(position.y || 0, 0, maxY || 0),
+      };
+    };
+
     const applyDock = (dock) => {
       if (dock === 'floating' && props.dock !== 'floating') {
-        emit('update:position', lastFloatingPosition.value);
+        emit('update:position', clampFloatingPosition(lastFloatingPosition.value));
       }
       if (dock !== 'floating') {
         preferredDock.value = dock;
@@ -309,7 +324,7 @@ export default {
         return;
       }
       emit('update:dock', 'floating');
-      emit('update:position', lastFloatingPosition.value);
+      emit('update:position', clampFloatingPosition(lastFloatingPosition.value));
     };
 
     const handleDoubleClick = () => {

--- a/src/core/config/controls.js
+++ b/src/core/config/controls.js
@@ -15,32 +15,32 @@ export const DIAGONAL_BINDINGS = [
 export const SKILL_BINDINGS = [
   {
     id: 'primary-attack',
-    keys: [' '],
+    keys: [' ', '1'],
     type: 'press',
   },
   {
     id: 'dash',
-    keys: ['shift'],
+    keys: ['shift', '2'],
     type: 'press',
   },
   {
     id: 'ability-1',
-    keys: ['q'],
+    keys: ['q', '3'],
     type: 'press',
   },
   {
     id: 'ability-2',
-    keys: ['e'],
+    keys: ['e', '4'],
     type: 'press',
   },
   {
     id: 'ability-3',
-    keys: ['r'],
+    keys: ['r', '5'],
     type: 'press',
   },
   {
     id: 'ability-4',
-    keys: ['f'],
+    keys: ['f', '6'],
     type: 'press',
   },
 ];

--- a/tests/unit/input-controller.spec.js
+++ b/tests/unit/input-controller.spec.js
@@ -1,0 +1,62 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import InputController from '../../src/core/utilities/input-controller.js';
+
+const keyEvent = (key, extra = {}) => ({
+  key,
+  preventDefault: vi.fn(),
+  ...extra,
+});
+
+describe('InputController', () => {
+  it('maps displayed quickbar number keys to their skills while the canvas has focus', () => {
+    const onSkill = vi.fn();
+    const controller = new InputController({ onSkill });
+
+    expect(controller.handleKeyDown(keyEvent('1'))).toBe(true);
+    expect(controller.handleKeyDown(keyEvent('2'))).toBe(true);
+    expect(controller.handleKeyDown(keyEvent('6'))).toBe(true);
+
+    expect(onSkill).toHaveBeenNthCalledWith(1, expect.objectContaining({
+      skillId: 'primary-attack',
+      phase: 'start',
+    }));
+    expect(onSkill).toHaveBeenNthCalledWith(2, expect.objectContaining({
+      skillId: 'dash',
+      phase: 'start',
+    }));
+    expect(onSkill).toHaveBeenNthCalledWith(3, expect.objectContaining({
+      skillId: 'ability-4',
+      phase: 'start',
+    }));
+  });
+
+  it('keeps legacy combat key aliases available', () => {
+    const onSkill = vi.fn();
+    const controller = new InputController({ onSkill });
+
+    [' ', 'Shift', 'q', 'e', 'r', 'f'].forEach((key) => {
+      expect(controller.handleKeyDown(keyEvent(key))).toBe(true);
+    });
+
+    expect(onSkill).toHaveBeenCalledTimes(6);
+    expect(onSkill.mock.calls.map(([payload]) => payload.skillId)).toEqual([
+      'primary-attack',
+      'dash',
+      'ability-1',
+      'ability-2',
+      'ability-3',
+      'ability-4',
+    ]);
+  });
+
+  it('ignores repeated press-skill keydown events', () => {
+    const onSkill = vi.fn();
+    const controller = new InputController({ onSkill });
+
+    expect(controller.handleKeyDown(keyEvent('3'))).toBe(true);
+    expect(controller.handleKeyDown(keyEvent('3', { repeat: true }))).toBe(true);
+
+    expect(onSkill).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
### Motivation
- Make core combat input consistent with the HUD by letting the visible quickbar numbers trigger skills when the game canvas has focus, while preserving legacy key aliases and avoiding accidental actions. 
- Improve discoverability and robustness of the UI by adding lightweight control hints and defensively handling edge cases in context menus, canvas clicks, and floating panels.

### Description
- Add quickbar number aliases to in-game input by extending `SKILL_BINDINGS` to include `1`–`6` alongside the existing Space/Shift/Q/E/R/F mappings so canvas-focused key events activate the expected skills via `InputController`.
- Improve the HUD and quickbar UX by adding an inline controls hint, richer quickbar tooltips (`slotTitle`), cooldown labels, and disabling activation for empty slots so buttons reflect available actions (`Quickbar.vue`, `GameHUD.vue`).
- Harden context menu and canvas click flows by ignoring invalid menu items, clamping context menu placement inside the viewport, closing empty menus, and preventing left-clicks with no valid action from emitting gameplay actions (`ContextMenu.vue`, `GameCanvas.vue`).
- Fix floating-window drag/dock behavior by preserving drag movement state for snap detection and clamping restored floating positions so windows remain inside bounds after dock toggles (`FloatingWindow.vue`).
- Add unit coverage for `InputController` to verify number-key quickbar aliases, legacy key aliases, and suppression of repeated press-skill keydown events (`tests/unit/input-controller.spec.js`).

### Testing
- Ran `npm run lint` and the linter completed successfully. (pass)
- Ran `npm run lint:css` after a small CSS cleanup and it completed successfully. (pass)
- Ran `npm run test:unit` and all unit tests passed: `Test Files 16 passed`, `Tests 102 passed`. (pass)
- Ran `npm run build` (Vite) and production build completed successfully. (pass)
- Attempted to capture a screenshot via Playwright but it failed because browser binaries are not installed in the environment; Playwright requires `npx playwright install`. (skipped)
- Note: invoking `vitest` with the unsupported `--runInBand` option failed earlier because Vitest does not accept that option; tests were re-run without it and passed. (informational)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a24ba8efab48321ab985aae840799c2)